### PR TITLE
Make TorrentClientBuilder public

### DIFF
--- a/bt-core/src/main/java/bt/TorrentClientBuilder.java
+++ b/bt-core/src/main/java/bt/TorrentClientBuilder.java
@@ -19,7 +19,7 @@ import java.net.URL;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-class TorrentClientBuilder<B extends TorrentClientBuilder> extends BaseClientBuilder<B> {
+public class TorrentClientBuilder<B extends TorrentClientBuilder> extends BaseClientBuilder<B> {
 
     private Storage storage;
 


### PR DESCRIPTION
I'm having some problems with this class because it's not public. When using this as a java library from my scala project the visibility of this class causes an IllegalAccessException when I try to instantiate StandaloneClientBuilder