### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <sup>
 A full-featured BitTorrent implementation in Java 8
 <br/><a href="http://bittorrent.org/beps/bep_0011.html">peer exchange</a> | <a href="http://bittorrent.org/beps/bep_0009.html">magnet links</a> | <a href="http://bittorrent.org/beps/bep_0005.html">DHT</a> | <a href="http://wiki.vuze.com/w/Message_Stream_Encryption">encryption</a> | <a href="http://bittorrent.org/beps/bep_0014.html">LSD</a> | <a href="http://bittorrent.org/beps/bep_0027.html">private trackers</a> | <a href="http://bittorrent.org/beps/bep_0010.html">extended protocol</a>
-</sup> 
+</sup>
 </strong></p>
 
 <p align="center">
@@ -37,6 +37,10 @@ A full-featured BitTorrent implementation in Java 8
     <a href="https://codecov.io/gh/atomashpolskiy/bt">
         <img src="https://img.shields.io/codecov/c/github/atomashpolskiy/bt/master.svg"
              alt="Coverage">
+    </a>
+    <a href="https://www.codetriage.com/atomashpolskiy/bt">
+        <img src="https://www.codetriage.com/atomashpolskiy/bt/badges/users.svg"
+             alt="Help Contribute to Open Source">
     </a>
 </p>
 
@@ -70,7 +74,7 @@ Declare the following dependencies in your project’s **pom.xml**:
     <artifactId>bt-core</artifactId>
     <version>${bt-version}</version>
 </dependency>
-<!-- for the sake of keeping the core with minimum number of 3-rd party 
+<!-- for the sake of keeping the core with minimum number of 3-rd party
      dependencies HTTP tracker support is shipped as a separate module;
      you may omit this dependency if only UDP trackers are going to be used -->
 <dependency>


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.