### PR TITLE
Avoid logging of potentially sensitive query in HttpTracker.

### DIFF
--- a/bt-core/src/main/java/bt/tracker/udp/UdpTracker.java
+++ b/bt-core/src/main/java/bt/tracker/udp/UdpTracker.java
@@ -157,8 +157,11 @@ class UdpTracker implements Tracker {
 
     @Override
     public String toString() {
+        final String trackerUrl = this.trackerUrl.toString().replace("http://", "udp://");
+        final String query = this.trackerUrl.getQuery();
+        final String maskedTrackerUrl = query == null ? trackerUrl : trackerUrl.replace(query, "{hidden}");
         return "UdpTracker{" +
-                "trackerUrl=" + trackerUrl +
+                "trackerUrl=" + maskedTrackerUrl +
                 '}';
     }
 }

--- a/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTracker.java
+++ b/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTracker.java
@@ -145,7 +145,7 @@ public class HttpTracker implements Tracker {
         try {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("Executing tracker HTTP request of type " + eventType.name() +
-                        "; request URL: " + requestUri);
+                        "; request URL: " + requestUri.replace(baseUri.getQuery(), "{hidden}"));
             }
             return httpClient.execute(request, httpResponseHandler);
         } catch (IOException e) {

--- a/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTracker.java
+++ b/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTracker.java
@@ -144,8 +144,10 @@ public class HttpTracker implements Tracker {
         HttpGet request = new HttpGet(requestUri);
         try {
             if (LOGGER.isDebugEnabled()) {
+                final String query = baseUri.getQuery();
+                final String maskedRequestUri = query == null ? requestUri : requestUri.replace(query, "{hidden}");
                 LOGGER.debug("Executing tracker HTTP request of type " + eventType.name() +
-                        "; request URL: " + requestUri.replace(baseUri.getQuery(), "{hidden}"));
+                        "; request URL: " + maskedRequestUri);
             }
             return httpClient.execute(request, httpResponseHandler);
         } catch (IOException e) {

--- a/bt-tests/src/test/java/bt/tracker/udp/MockRuntimeLifecycleBinder.java
+++ b/bt-tests/src/test/java/bt/tracker/udp/MockRuntimeLifecycleBinder.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016—2018 Andrei Tomashpolskiy and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bt.tracker.udp;
+
+import bt.service.IRuntimeLifecycleBinder;
+import bt.service.LifecycleBinding;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Oleg Ermolaev Date: 17.02.2018 1:49
+ */
+class MockRuntimeLifecycleBinder implements IRuntimeLifecycleBinder {
+    private Runnable onShutdown;
+
+    @Override
+    public void onStartup(Runnable r) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onStartup(String description, Runnable r) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onStartup(LifecycleBinding binding) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onShutdown(Runnable runnable) {
+        this.onShutdown = runnable;
+    }
+
+    @Override
+    public void onShutdown(String description, Runnable runnable) {
+        this.onShutdown = runnable;
+    }
+
+    @Override
+    public void onShutdown(LifecycleBinding binding) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addBinding(LifecycleEvent event, LifecycleBinding binding) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void visitBindings(LifecycleEvent event, Consumer<LifecycleBinding> consumer) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void shutdown() {
+        onShutdown.run();
+    }
+}

--- a/bt-tests/src/test/java/bt/tracker/udp/UdpTrackerToStringTest.java
+++ b/bt-tests/src/test/java/bt/tracker/udp/UdpTrackerToStringTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016—2018 Andrei Tomashpolskiy and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bt.tracker.udp;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Oleg Ermolaev Date: 17.02.2018 1:28
+ */
+public class UdpTrackerToStringTest {
+    private MockRuntimeLifecycleBinder mockRuntimeLifecycleBinder;
+
+    @Before
+    public void setUp() throws Exception {
+        mockRuntimeLifecycleBinder = new MockRuntimeLifecycleBinder();
+    }
+
+    @After
+    public void tearDown() {
+        mockRuntimeLifecycleBinder.shutdown();
+    }
+
+    @Test
+    public void testNoQuery() {
+        final String trackerUrl = "udp://tracker.local";
+        final UdpTracker udpTracker = createTracker(trackerUrl);
+        assertFalse(udpTracker.toString().contains("http://"));
+        assertTrue(udpTracker.toString().contains(trackerUrl));
+    }
+
+    @Test
+    public void testQuery() {
+        final String trackerUrl = "udp://tracker.local?";
+        final String query = "key=value";
+        final String fullTrackerUrl = trackerUrl + query;
+        final UdpTracker udpTracker = createTracker(fullTrackerUrl);
+        assertTrue(udpTracker.toString().contains(trackerUrl));
+        assertFalse(udpTracker.toString().contains(query));
+    }
+
+    @Test
+    public void testSensitiveQuery() {
+        final String sensitive = "HideMePlease";
+        final String trackerUrl = "udp://tracker.local?";
+        final String fullTrackerUrl = trackerUrl + "private-key=" + sensitive;
+        final UdpTracker udpTracker = createTracker(fullTrackerUrl);
+        assertTrue(udpTracker.toString().contains(trackerUrl));
+        assertFalse(udpTracker.toString().contains(sensitive));
+    }
+
+    private UdpTracker createTracker(String trackerUrl) {
+        return new UdpTracker(null, mockRuntimeLifecycleBinder, null, 0, 0, trackerUrl);
+    }
+}


### PR DESCRIPTION
In come cases that query contains users private key. For security reasons private key mast be excluded from logs.
Same work need to be done for UDP tracker.