### PR TITLE
NPE in SocketChannelHandler

### DIFF
--- a/bt-core/src/main/java/bt/net/pipeline/ChannelHandler.java
+++ b/bt-core/src/main/java/bt/net/pipeline/ChannelHandler.java
@@ -67,9 +67,10 @@ public interface ChannelHandler {
     /**
      * Request to write pending outgoing data to the underlying channel.
      *
+     * @return true, if the message has been flushed
      * @since 1.6
      */
-    void flush();
+    boolean flush();
 
     /**
      * Request to close.


### PR DESCRIPTION
Fixed NPE in 'SocketChannelHandler.flush()'

Don't invoke `outboundBuffer.unlock();` because that behaviour used in `DefaultChannelPipeline#encode`

https://github.com/atomashpolskiy/bt/blob/a37ca29f3585d0b34a2fbeb532a92368432dae9c/bt-core/src/main/java/bt/net/pipeline/DefaultChannelPipeline.java#L121-L136
