### PR TITLE
Configuring cling network transports

### DIFF
--- a/bt-upnp/pom.xml
+++ b/bt-upnp/pom.xml
@@ -25,6 +25,7 @@
 
     <properties>
         <cling.version>2.1.1</cling.version>
+        <jetty.version>8.2.0.v20160908</jetty.version>
     </properties>
 
     <dependencies>
@@ -33,7 +34,6 @@
             <artifactId>bt-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.fourthline.cling</groupId>
             <artifactId>cling-core</artifactId>
@@ -43,6 +43,33 @@
             <groupId>org.fourthline.cling</groupId>
             <artifactId>cling-support</artifactId>
             <version>${cling.version}</version>
+        </dependency>
+        <!-- Jetty StreamClientImpl [http://4thline.org/projects/cling/core/manual/cling-core-manual.xhtml] #6.6 -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <!-- Jetty AsyncServletStreamServerImpl [http://4thline.org/projects/cling/core/manual/cling-core-manual.xhtml] #6.6 -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${jetty.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/bt-upnp/src/main/java/bt/portmapping/upnp/UpnpPortMapperModule.java
+++ b/bt-upnp/src/main/java/bt/portmapping/upnp/UpnpPortMapperModule.java
@@ -17,7 +17,9 @@
 package bt.portmapping.upnp;
 
 import bt.module.ServiceModule;
+import bt.portmapping.upnp.jetty.JettyAsyncUpnpServiceConfiguration;
 import com.google.inject.AbstractModule;
+import org.fourthline.cling.UpnpServiceConfiguration;
 
 /**
  * @since 1.8
@@ -28,6 +30,7 @@ public class UpnpPortMapperModule extends AbstractModule {
     protected void configure() {
         ServiceModule.extend(binder()).addPortMapper(UpnpPortMapper.class);
 
+        bind(UpnpServiceConfiguration.class).to(JettyAsyncUpnpServiceConfiguration.class);
         bind(UpnpPortMappingServicesRegistrar.class);
     }
 }

--- a/bt-upnp/src/main/java/bt/portmapping/upnp/UpnpPortMappingServicesRegistrar.java
+++ b/bt-upnp/src/main/java/bt/portmapping/upnp/UpnpPortMappingServicesRegistrar.java
@@ -18,6 +18,8 @@ package bt.portmapping.upnp;
 
 import bt.service.IRuntimeLifecycleBinder;
 import bt.service.LifecycleBinding;
+import org.fourthline.cling.UpnpService;
+import org.fourthline.cling.UpnpServiceConfiguration;
 import org.fourthline.cling.UpnpServiceImpl;
 import org.fourthline.cling.support.igd.PortMappingListener;
 import org.fourthline.cling.support.model.PortMapping;
@@ -36,10 +38,12 @@ import static bt.service.IRuntimeLifecycleBinder.LifecycleEvent.SHUTDOWN;
 public class UpnpPortMappingServicesRegistrar {
 
     private final IRuntimeLifecycleBinder lifecycleBinder;
+    private final UpnpServiceConfiguration upnpServiceConfiguration;
 
     @Inject
-    public UpnpPortMappingServicesRegistrar(IRuntimeLifecycleBinder lifecycleBinder) {
+    public UpnpPortMappingServicesRegistrar(IRuntimeLifecycleBinder lifecycleBinder, UpnpServiceConfiguration upnpServiceConfiguration) {
         this.lifecycleBinder = lifecycleBinder;
+        this.upnpServiceConfiguration = upnpServiceConfiguration;
     }
 
     /**
@@ -48,16 +52,17 @@ public class UpnpPortMappingServicesRegistrar {
      * @param portMapping desired port mapping;
      */
     public void registerPortMapping(PortMapping portMapping) {
-        final UpnpServiceImpl service = new UpnpServiceImpl(new PortMappingListener(portMapping));
+        final UpnpService service = new UpnpServiceImpl(upnpServiceConfiguration, new PortMappingListener(portMapping));
         service.getControlPoint().search();
         bindShutdownHook(service);
     }
 
-    private void bindShutdownHook(UpnpServiceImpl service) {
+    private void bindShutdownHook(UpnpService service) {
         lifecycleBinder.addBinding(SHUTDOWN,
                 LifecycleBinding.bind(service::shutdown)
                         .description("Disables port mapping on application shutdown.")
                         .async()
                         .build());
     }
+
 }

--- a/bt-upnp/src/main/java/bt/portmapping/upnp/jetty/JettyAsyncUpnpServiceConfiguration.java
+++ b/bt-upnp/src/main/java/bt/portmapping/upnp/jetty/JettyAsyncUpnpServiceConfiguration.java
@@ -1,0 +1,37 @@
+package bt.portmapping.upnp.jetty;
+
+import org.fourthline.cling.DefaultUpnpServiceConfiguration;
+import org.fourthline.cling.model.Namespace;
+import org.fourthline.cling.transport.spi.NetworkAddressFactory;
+import org.fourthline.cling.transport.spi.StreamClient;
+import org.fourthline.cling.transport.spi.StreamServer;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class JettyAsyncUpnpServiceConfiguration extends DefaultUpnpServiceConfiguration {
+
+    @Override
+    protected Namespace createNamespace() {
+        return new Namespace("/bt-upnp");
+    }
+
+    @Override
+    public StreamClient createStreamClient() {
+        return new org.fourthline.cling.transport.impl.jetty.StreamClientImpl(
+                new org.fourthline.cling.transport.impl.jetty.StreamClientConfigurationImpl(
+                        getSyncProtocolExecutorService()
+                )
+        );
+    }
+
+    @Override
+    public StreamServer createStreamServer(NetworkAddressFactory networkAddressFactory) {
+        return new org.fourthline.cling.transport.impl.AsyncServletStreamServerImpl(
+                new org.fourthline.cling.transport.impl.AsyncServletStreamServerConfigurationImpl(
+                        org.fourthline.cling.transport.impl.jetty.JettyServletContainer.INSTANCE,
+                        networkAddressFactory.getStreamListenPort()
+                )
+        );
+    }
+}


### PR DESCRIPTION
Hi

I created this PR because the default StreamClientImpl doesn't work most of the times (tried on Mac OSX Mojave and Windows 10).

I think it's not really necessary to leave the option to switch implementation because the Jetty version should be better and although it comes at the cost of more dependencies ¯\_(ツ)_/¯ the jar is just 10kb

The change follows cling manual directions:
http://4thline.org/projects/cling/core/manual/cling-core-manual.xhtml#section.ConfiguringTransports