### PR TITLE
Continuous assignments

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,7 @@ For the latest information visit project web site: http://atomashpolskiy.github.
 
 * onTorrentStarted called twice [#117](https://github.com/atomashpolskiy/bt/issues/117)
 * Add new onMetadataAvailable event (fired after torrent's metadata has been fetched)
+* Continuous piece assignments (better request pipelining)
 
 ## 1.8
 

--- a/bt-core/src/main/java/bt/data/BlockSet.java
+++ b/bt-core/src/main/java/bt/data/BlockSet.java
@@ -83,4 +83,11 @@ public interface BlockSet {
      * @since 1.2
      */
     boolean isEmpty();
+
+    /**
+     * Reset block presence information (may not perform actual deletion of data)
+     *
+     * @since 1.9
+     */
+    void clear();
 }

--- a/bt-core/src/main/java/bt/data/DefaultChunkDescriptor.java
+++ b/bt-core/src/main/java/bt/data/DefaultChunkDescriptor.java
@@ -86,4 +86,9 @@ class DefaultChunkDescriptor implements ChunkDescriptor {
     public boolean isEmpty() {
         return blockSet.isEmpty();
     }
+
+    @Override
+    public void clear() {
+        blockSet.clear();
+    }
 }

--- a/bt-core/src/main/java/bt/data/range/MutableBlockSet.java
+++ b/bt-core/src/main/java/bt/data/range/MutableBlockSet.java
@@ -99,6 +99,11 @@ class MutableBlockSet implements BlockSet {
         return bitmask.isEmpty();
     }
 
+    @Override
+    public void clear() {
+        bitmask.clear();
+    }
+
     /*
     // TODO rewrite description
      * This method implements a simple strategy to track which blocks have been written:

--- a/bt-core/src/main/java/bt/data/range/SynchronizedBlockSet.java
+++ b/bt-core/src/main/java/bt/data/range/SynchronizedBlockSet.java
@@ -85,4 +85,14 @@ class SynchronizedBlockSet implements BlockSet {
             lock.unlock();
         }
     }
+
+    @Override
+    public void clear() {
+        lock.lock();
+        try {
+            delegate.clear();
+        } finally {
+            lock.unlock();
+        }
+    }
 }

--- a/bt-core/src/main/java/bt/torrent/data/DefaultDataWorker.java
+++ b/bt-core/src/main/java/bt/torrent/data/DefaultDataWorker.java
@@ -114,6 +114,9 @@ class DefaultDataWorker implements DataWorker {
                             boolean verified = verifier.verify(chunk);
                             if (verified) {
                                 data.getBitfield().markVerified(pieceIndex);
+                            } else {
+                                // reset data
+                                chunk.clear();
                             }
                             return verified;
                         }, executor);

--- a/bt-core/src/main/java/bt/torrent/messaging/Assignment.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/Assignment.java
@@ -17,15 +17,23 @@
 package bt.torrent.messaging;
 
 import bt.net.Peer;
+import bt.data.Bitfield;
+import bt.torrent.BitfieldBasedStatistics;
+import bt.torrent.selector.PieceSelector;
 
 import java.time.Duration;
+import java.util.*;
 
 class Assignment {
 
     enum Status { ACTIVE, DONE, TIMEOUT };
 
     private Peer peer;
-    private Integer piece;
+    private PieceSelector selector;
+    private BitfieldBasedStatistics pieceStatistics;
+    private Assignments assignments;
+
+    private Queue<Integer> pieces;
     private ConnectionState connectionState;
 
     private final Duration limit;
@@ -34,27 +42,51 @@ class Assignment {
     private long checked;
 
     private boolean aborted;
-    private boolean finished;
 
-    Assignment(Peer peer, Integer piece, Duration limit) {
+    Assignment(Peer peer, Duration limit, PieceSelector selector,
+               BitfieldBasedStatistics pieceStatistics, Assignments assignments) {
         this.peer = peer;
-        this.piece = piece;
+        this.selector = selector;
+        this.pieceStatistics = pieceStatistics;
+        this.assignments = assignments;
+
         this.limit = limit;
+        this.pieces = new ArrayDeque<>();
+
+        claimPiecesIfNeeded();
     }
 
     Peer getPeer() {
         return peer;
     }
 
-    Integer getPiece() {
-        return piece;
+    Queue<Integer> getPieces() {
+        return pieces;
+    }
+
+    private void claimPiecesIfNeeded() {
+        // TODO: change this to a configurable setting?
+        int n = 3;
+        if (pieces.size() < n) {
+            Bitfield peerBitfield = pieceStatistics.getPeerBitfield(peer).get();
+            Iterator<Integer> iter = selector.getNextPieces(pieceStatistics).iterator();
+            while (iter.hasNext() && pieces.size() < 3) {
+                // TODO: during endgame we need to choose the next piece randomly (see commented code in Assignments)
+                Integer pieceIndex = iter.next();
+                if (peerBitfield.isVerified(pieceIndex) && assignments.claim(pieceIndex)) {
+                    pieces.add(pieceIndex);
+                }
+            }
+        }
+    }
+
+    boolean isAssigned(int pieceIndex) {
+        return pieces.contains(pieceIndex);
     }
 
     Status getStatus() {
-        if (finished) {
-            return Status.DONE;
-        } else if (started > 0) {
-            long duration = System.currentTimeMillis() - started;
+        if (started > 0) {
+            long duration = System.currentTimeMillis() - checked;
             if (duration > limit.toMillis()) {
                 return Status.TIMEOUT;
             }
@@ -66,28 +98,29 @@ class Assignment {
         if (this.connectionState != null) {
             throw new IllegalStateException("Assignment is already started");
         }
-        if (aborted || finished) {
-            throw new IllegalStateException("Assignment is already done");
+        if (aborted) {
+            throw new IllegalStateException("Assignment is aborted");
         }
         this.connectionState = connectionState;
         connectionState.setCurrentAssignment(this);
         started = System.currentTimeMillis();
+        checked = started;
     }
 
     void check() {
         checked = System.currentTimeMillis();
     }
 
-    void finish() {
-        finished = !aborted;
-        if (finished && connectionState != null) {
-            connectionState.removeAssignment();
+    void finish(Integer pieceIndex) {
+        if (pieces.remove(pieceIndex)) {
+            assignments.finish(pieceIndex);
+            claimPiecesIfNeeded();
         }
     }
 
     void abort() {
-        aborted = !finished;
-        if (aborted && connectionState != null) {
+        aborted = true;
+        if (connectionState != null) {
             connectionState.removeAssignment();
         }
     }
@@ -95,13 +128,12 @@ class Assignment {
     @Override
     public String toString() {
         return "Assignment{" +
-                "piece=" + piece +
+                "pieces=" + pieces +
                 ", peer=" + peer +
                 ", started=" + started +
                 ", limit=" + limit +
                 ", checked=" + checked +
                 ", aborted=" + aborted +
-                ", finished=" + finished +
                 '}';
     }
 }

--- a/bt-core/src/main/java/bt/torrent/messaging/Assignments.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/Assignments.java
@@ -21,24 +21,15 @@ import bt.net.Peer;
 import bt.runtime.Config;
 import bt.torrent.BitfieldBasedStatistics;
 import bt.torrent.selector.PieceSelector;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 
 public class Assignments {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Assignments.class);
-
-    private static final int MAX_ASSIGNED_PIECES_PER_PEER = 50;
 
     private Config config;
 
@@ -48,9 +39,6 @@ public class Assignments {
 
     private Set<Integer> assignedPieces;
     private Map<Peer, Assignment> assignments;
-    private Map<Peer, LinkedList<Integer>> peers;
-
-    private Random random;
 
     public Assignments(Bitfield bitfield, PieceSelector selector, BitfieldBasedStatistics pieceStatistics, Config config) {
         this.bitfield = bitfield;
@@ -60,9 +48,6 @@ public class Assignments {
 
         this.assignedPieces = new HashSet<>();
         this.assignments = new HashMap<>();
-        this.peers = new HashMap<>();
-
-        this.random = new Random(System.currentTimeMillis());
     }
 
     public Assignment get(Peer peer) {
@@ -72,160 +57,59 @@ public class Assignments {
     public void remove(Assignment assignment) {
         assignment.abort();
         assignments.remove(assignment.getPeer());
-        assignedPieces.remove(assignment.getPiece());
+        // TODO: investigate on how this might affect endgame?
+        assignedPieces.removeAll(assignment.getPieces());
     }
 
     public int count() {
         return assignments.size();
     }
 
-    public int workersCount() {
-        return peers.size();
-    }
-
     public Optional<Assignment> assign(Peer peer) {
-        LinkedList<Integer> pieces = peers.get(peer);
-        if (pieces == null || pieces.isEmpty()) {
+        if (!hasInterestingPieces(peer)) {
             return Optional.empty();
         }
 
-        boolean endgame = isEndgame();
-
-        StringBuilder buf = LOGGER.isTraceEnabled() ? new StringBuilder() : null;
-        if (LOGGER.isTraceEnabled()) {
-            buf.append("Trying to claim next assignment for peer ");
-            buf.append(peer);
-            buf.append(". Number of remaining pieces: ");
-            buf.append(bitfield.getPiecesRemaining());
-            buf.append(", number of pieces in progress: ");
-            buf.append(assignedPieces.size());
-            buf.append(", endgame: " + endgame);
-            buf.append(". ");
-        }
-
-        Optional<Integer> selectedPiece;
-        if (endgame) {
-            // take random piece to minimize number of pieces
-            // requested from different peers at the same time
-            Integer pieceIndex = pieces.remove(random.nextInt(pieces.size()));
-            selectedPiece = Optional.of(pieceIndex);
-        } else {
-
-            Integer piece;
-            boolean assigned = true;
-            Iterator<Integer> iter = pieces.iterator();
-            do {
-                piece = iter.next();
-                if (bitfield.isComplete(piece)) {
-                    iter.remove();
-                    if (LOGGER.isTraceEnabled()) {
-                        buf.append("Checking next piece in queue: {" + piece + "}; piece is completed. ");
-                    }
-                    continue;
-                }
-                assigned = assignedPieces.contains(piece);
-                if (assigned && LOGGER.isTraceEnabled()) {
-                    buf.append("Checking next piece in queue: {" + piece + "}; piece is assigned. ");
-                }
-            } while (assigned && iter.hasNext());
-
-            if (!assigned) {
-                iter.remove();
-            }
-            selectedPiece = assigned ? Optional.empty() : Optional.of(piece);
-        }
-
-        if (LOGGER.isTraceEnabled()) {
-            if (selectedPiece.isPresent()) {
-                buf.append(" => Assigning piece #");
-                buf.append(selectedPiece.get());
-                buf.append(" to current peer");
-            } else {
-                buf.append(" => No pieces to assign.");
-            }
-            LOGGER.trace(buf.toString());
-        }
-
-        return selectedPiece.isPresent() ? Optional.of(assign(peer, selectedPiece.get())) : Optional.empty();
+        Assignment assignment = new Assignment(peer, config.getMaxPieceReceivingTime(),
+                selector, pieceStatistics, this);
+        assignments.put(peer, assignment);
+        return Optional.of(assignment);
+//        if (endgame) {
+//            // take random piece to minimize number of pieces
+//            // requested from different peers at the same time
+//            Integer pieceIndex = pieces.remove(random.nextInt(pieces.size()));
+//            selectedPiece = Optional.of(pieceIndex);
+//        }
     }
 
-    private boolean isEndgame() {
+    public boolean claim(Integer pieceIndex) {
+        boolean claimed = isEndgame() || (!bitfield.isComplete(pieceIndex) && !assignedPieces.contains(pieceIndex));
+        if (claimed) {
+            assignedPieces.add(pieceIndex);
+        }
+        return claimed;
+    }
+
+    public void finish(Integer pieceIndex) {
+        assignedPieces.remove(pieceIndex);
+    }
+
+    public boolean isEndgame() {
         // if all remaining pieces are requested,
         // that would mean that we have entered the "endgame" mode
         return bitfield.getPiecesRemaining() <= assignedPieces.size();
     }
 
-    private Assignment assign(Peer peer, Integer piece) {
-        Assignment assignment = new Assignment(peer, piece, config.getMaxPieceReceivingTime());
-        assignments.put(peer, assignment);
-        assignedPieces.add(piece);
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Assigning piece #{} to peer: {}", piece, peer);
-        }
-        return assignment;
-    }
-
     /**
-     * Updates the lists of interesting pieces for the provided peers.
-     *
      * @return Collection of peers that have interesting pieces and can be given an assignment
      */
-    // TODO: select from seeders first
     public Set<Peer> update(Set<Peer> ready, Set<Peer> choking) {
-        Iterator<Integer> suggested = selector.getNextPieces(pieceStatistics).iterator();
-        if (LOGGER.isTraceEnabled()) {
-            LOGGER.trace("Updating assignments. Piece selector has more pieces: {}, number of ready peers: {}, number of assigned peers: {}",
-                    suggested.hasNext(), ready.size(), assignments.size());
-        }
-        final Set<Peer> readyPeers = new HashSet<>(ready);
-        while (suggested.hasNext() && readyPeers.size() > 0) {
-            Integer piece = suggested.next();
-
-            final Iterator<Peer> iter = readyPeers.iterator();
-            while (iter.hasNext()) {
-                Peer peer = iter.next();
-                Optional<Bitfield> peerBitfield = pieceStatistics.getPeerBitfield(peer);
-                if (!peerBitfield.isPresent()) {
-                    iter.remove();
-                    continue;
-                }
-                LinkedList<Integer> queue = peers.get(peer);
-                if (queue != null && queue.size() > MAX_ASSIGNED_PIECES_PER_PEER) {
-                    iter.remove();
-                    continue;
-                }
-                boolean hasPiece = peerBitfield.get().isVerified(piece);
-                if (hasPiece) {
-                    if (queue == null) {
-                        queue = new LinkedList<>();
-                        peers.put(peer, queue);
-                    }
-                    if (!queue.contains(piece)) {
-                        queue.add(piece);
-                        if (queue.size() > MAX_ASSIGNED_PIECES_PER_PEER) {
-                            iter.remove();
-                        }
-                        if (LOGGER.isTraceEnabled()) {
-                            LOGGER.trace("Adding piece #{} to peer's queue: {}. Number of pieces in peer's queue: {}",
-                                    piece, peer, queue.size());
-                        }
-                    }
-                }
+        Set<Peer> result = new HashSet<>();
+        for (Peer peer : ready) {
+            if (hasInterestingPieces(peer)) {
+                result.add(peer);
             }
         }
-
-        Iterator<Map.Entry<Peer, LinkedList<Integer>>> iter = peers.entrySet().iterator();
-        while (iter.hasNext()) {
-            Map.Entry<Peer, LinkedList<Integer>> e = iter.next();
-            Peer peer = e.getKey();
-            LinkedList<Integer> pieces = e.getValue();
-
-            if (!ready.contains(peer) || pieces.isEmpty()) {
-                iter.remove();
-            }
-        }
-
-        Set<Peer> result = new HashSet<>(peers.keySet());
         for (Peer peer : choking) {
             if (hasInterestingPieces(peer)) {
                 result.add(peer);

--- a/bt-core/src/main/java/bt/torrent/messaging/Assignments.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/Assignments.java
@@ -74,12 +74,6 @@ public class Assignments {
                 selector, pieceStatistics, this);
         assignments.put(peer, assignment);
         return Optional.of(assignment);
-//        if (endgame) {
-//            // take random piece to minimize number of pieces
-//            // requested from different peers at the same time
-//            Integer pieceIndex = pieces.remove(random.nextInt(pieces.size()));
-//            selectedPiece = Optional.of(pieceIndex);
-//        }
     }
 
     public boolean claim(Integer pieceIndex) {

--- a/bt-core/src/main/java/bt/torrent/messaging/Assignments.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/Assignments.java
@@ -77,7 +77,7 @@ public class Assignments {
     }
 
     public boolean claim(Integer pieceIndex) {
-        boolean claimed = isEndgame() || (!bitfield.isComplete(pieceIndex) && !assignedPieces.contains(pieceIndex));
+        boolean claimed = !bitfield.isComplete(pieceIndex) && (isEndgame() ||  !assignedPieces.contains(pieceIndex));
         if (claimed) {
             assignedPieces.add(pieceIndex);
         }

--- a/bt-core/src/main/java/bt/torrent/messaging/ConnectionState.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/ConnectionState.java
@@ -20,14 +20,8 @@ import bt.protocol.Cancel;
 import bt.protocol.Request;
 import bt.torrent.data.BlockWrite;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Contains basic information about a connection's state.
@@ -51,8 +45,8 @@ public class ConnectionState {
     private Set<Object> pendingRequests;
     private Map<Object, CompletableFuture<BlockWrite>> pendingWrites;
 
+    private Set<Integer> enqueuedPieces;
     private Queue<Request> requestQueue;
-    private boolean initializedRequestQueue;
     private Optional<Assignment> assignment;
 
     ConnectionState() {
@@ -63,7 +57,8 @@ public class ConnectionState {
         this.pendingRequests = new HashSet<>();
         this.pendingWrites = new HashMap<>();
 
-        this.requestQueue = new LinkedBlockingQueue<>();
+        this.enqueuedPieces = new HashSet<>();
+        this.requestQueue = new ArrayDeque<>();
 
         this.assignment = Optional.empty();
     }
@@ -246,16 +241,12 @@ public class ConnectionState {
     // Methods below are not a part of the public API //
     /**************************************************/
 
+    Set<Integer> getEnqueuedPieces() {
+        return enqueuedPieces;
+    }
+
     Queue<Request> getRequestQueue() {
         return requestQueue;
-    }
-
-    boolean initializedRequestQueue() {
-        return initializedRequestQueue;
-    }
-
-    void setInitializedRequestQueue(boolean initializedRequestQueue) {
-        this.initializedRequestQueue = initializedRequestQueue;
     }
 
     Optional<Assignment> getCurrentAssignment() {

--- a/bt-core/src/main/java/bt/torrent/messaging/PieceConsumer.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/PieceConsumer.java
@@ -120,7 +120,7 @@ public class PieceConsumer {
         connectionState.incrementDownloaded(block.length);
         if (connectionState.getCurrentAssignment().isPresent()) {
             Assignment assignment = connectionState.getCurrentAssignment().get();
-            if (pieceIndex == assignment.getPiece()) {
+            if (assignment.isAssigned(pieceIndex)) {
                 assignment.check();
             }
         }

--- a/bt-core/src/main/java/bt/torrent/messaging/RequestProducer.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/RequestProducer.java
@@ -30,10 +30,7 @@ import bt.torrent.data.BlockWrite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -69,20 +66,25 @@ public class RequestProducer {
         }
 
         Assignment assignment = connectionState.getCurrentAssignment().get();
-        int currentPiece = assignment.getPiece();
-        if (bitfield.isComplete(currentPiece)) {
-            assignment.finish();
+        Queue<Integer> assignedPieces = assignment.getPieces();
+        if (assignedPieces.isEmpty()) {
             resetConnection(connectionState, messageConsumer);
             if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("Finished downloading piece #{}", currentPiece);
+                LOGGER.trace("All pieces assigned to peer {} have been finished." +
+                        " Will wait for the next assignment.", peer);
             }
             return;
-        } else if (!connectionState.initializedRequestQueue()) {
-            connectionState.getPendingWrites().clear();
-            initializeRequestQueue(connectionState, currentPiece);
-            if (LOGGER.isTraceEnabled()) {
-                LOGGER.trace("Begin downloading piece #{} from peer: {}. Request queue length: {}",
-                        currentPiece, peer, connectionState.getRequestQueue().size());
+        } else {
+            Queue<Integer> _assignedPieces = new ArrayDeque<>(assignedPieces);
+            for (Integer assignedPiece : _assignedPieces) {
+                if (bitfield.isComplete(assignedPiece)) {
+                    assignment.finish(assignedPiece);
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("Finished downloading piece #{}", assignedPiece);
+                    }
+                } else {
+                    addRequestsToQueue(connectionState, assignedPiece);
+                }
             }
         }
 
@@ -97,7 +99,7 @@ public class RequestProducer {
 
     private void resetConnection(ConnectionState connectionState, Consumer<Message> messageConsumer) {
         connectionState.getRequestQueue().clear();
-        connectionState.setInitializedRequestQueue(false);
+        connectionState.getEnqueuedPieces().clear();
         connectionState.getPendingRequests().forEach(r -> {
             Mapper.decodeKey(r).ifPresent(key -> {
                 messageConsumer.accept(new Cancel(key.getPieceIndex(), key.getOffset(), key.getLength()));
@@ -106,33 +108,35 @@ public class RequestProducer {
         connectionState.getPendingRequests().clear();
     }
 
-    private void initializeRequestQueue(ConnectionState connectionState, int pieceIndex) {
-        List<Request> requests = buildRequests(pieceIndex).stream()
-            .filter(request -> {
-                Object key = Mapper.mapper().buildKey(
-                    request.getPieceIndex(), request.getOffset(), request.getLength());
-                if (connectionState.getPendingRequests().contains(key)) {
-                    return false;
-                }
+    private void addRequestsToQueue(ConnectionState connectionState, Integer pieceIndex) {
+        if (connectionState.getEnqueuedPieces().add(pieceIndex)) {
+            List<Request> requests = buildRequests(pieceIndex).stream()
+                    .filter(request -> {
+                        Object key = Mapper.mapper().buildKey(
+                                request.getPieceIndex(), request.getOffset(), request.getLength());
+                        if (connectionState.getPendingRequests().contains(key)) {
+                            return false;
+                        }
 
-                CompletableFuture<BlockWrite> future = connectionState.getPendingWrites().get(key);
-                if (future == null) {
-                    return true;
-                } else if (!future.isDone()) {
-                    return false;
-                }
+                        CompletableFuture<BlockWrite> future = connectionState.getPendingWrites().get(key);
+                        if (future == null) {
+                            return true;
+                        } else if (!future.isDone()) {
+                            return false;
+                        }
 
-                boolean failed = future.isDone() && future.getNow(null).getError().isPresent();
-                if (failed) {
-                    connectionState.getPendingWrites().remove(key);
-                }
-                return failed;
+                        boolean failed = future.isDone() && future.getNow(null).getError().isPresent();
+                        if (failed) {
+                            connectionState.getPendingWrites().remove(key);
+                        }
+                        return failed;
 
-            }).collect(Collectors.toList());
+                    }).collect(Collectors.toList());
 
-        Collections.shuffle(requests);
-        connectionState.getRequestQueue().addAll(requests);
-        connectionState.setInitializedRequestQueue(true);
+            Collections.shuffle(requests);
+
+            connectionState.getRequestQueue().addAll(requests);
+        }
     }
 
     private List<Request> buildRequests(int pieceIndex) {

--- a/bt-tests/src/test/java/bt/torrent/BaseBitfieldTest.java
+++ b/bt-tests/src/test/java/bt/torrent/BaseBitfieldTest.java
@@ -91,6 +91,11 @@ public abstract class BaseBitfieldTest {
             }
 
             @Override
+            public void clear() {
+                Arrays.fill(bitfield, (byte)0);
+            }
+
+            @Override
             public DataRange getData() {
                 throw new UnsupportedOperationException();
             }


### PR DESCRIPTION
Should significantly improve throughput by eliminating pauses, where we have to wait for all blocks of the previous piece to be received before issuing requests for the next piece, and instead continuously pipelining requests for multiple pieces.