### PR TITLE
fix two bugs and add acceptor port into thread name

### DIFF
--- a/bt-core/src/main/java/bt/module/ServiceModule.java
+++ b/bt-core/src/main/java/bt/module/ServiceModule.java
@@ -194,7 +194,7 @@ public class ServiceModule implements Module {
             ChunkVerifier verifier,
             BlockCache blockCache,
             Config config) {
-        return new DefaultDataWorker(lifecycleBinder, torrentRegistry, verifier, blockCache, config.getMaxIOQueueSize());
+        return new DefaultDataWorker(lifecycleBinder, torrentRegistry, verifier, blockCache, config);
     }
 
     @Provides

--- a/bt-core/src/main/java/bt/net/ConnectionSource.java
+++ b/bt-core/src/main/java/bt/net/ConnectionSource.java
@@ -56,9 +56,10 @@ public class ConnectionSource implements IConnectionSource {
         this.connectionPool = connectionPool;
         this.config = config;
 
+        String threadName = String.format("%d.bt.net.pool.connection-worker", config.getAcceptorPort());
         this.connectionExecutor = Executors.newFixedThreadPool(
                 config.getMaxPendingConnectionRequests(),
-                CountingThreadFactory.daemonFactory("bt.net.pool.connection-worker"));
+                CountingThreadFactory.daemonFactory(threadName));
         lifecycleBinder.onShutdown("Shutdown connection workers", connectionExecutor::shutdownNow);
 
         this.pendingConnections = new ConcurrentHashMap<>();

--- a/bt-core/src/main/java/bt/net/DataReceivingLoop.java
+++ b/bt-core/src/main/java/bt/net/DataReceivingLoop.java
@@ -18,6 +18,7 @@ package bt.net;
 
 import bt.module.PeerConnectionSelector;
 import bt.net.pipeline.ChannelHandlerContext;
+import bt.runtime.Config;
 import bt.service.IRuntimeLifecycleBinder;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
@@ -46,15 +47,17 @@ public class DataReceivingLoop implements Runnable, DataReceiver {
 
     @Inject
     public DataReceivingLoop(@PeerConnectionSelector SharedSelector selector,
-                             IRuntimeLifecycleBinder lifecycleBinder) {
+                             IRuntimeLifecycleBinder lifecycleBinder,
+                             Config config) {
         this.selector = selector;
         this.interestOpsUpdates = new ConcurrentHashMap<>();
 
-        schedule(lifecycleBinder);
+        schedule(lifecycleBinder, config);
     }
 
-    private void schedule(IRuntimeLifecycleBinder lifecycleBinder) {
-        ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "bt.net.data-receiver"));
+    private void schedule(IRuntimeLifecycleBinder lifecycleBinder, Config config) {
+        String threadName = String.format("%d.bt.net.data-receiver", config.getAcceptorPort());
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, threadName));
         lifecycleBinder.onStartup("Initialize message receiver", () -> executor.execute(this));
         lifecycleBinder.onShutdown("Shutdown message receiver", () -> {
             try {

--- a/bt-core/src/main/java/bt/net/IncomingConnectionListener.java
+++ b/bt-core/src/main/java/bt/net/IncomingConnectionListener.java
@@ -45,9 +45,10 @@ public class IncomingConnectionListener {
         this.connectionPool = connectionPool;
         this.config = config;
 
+        String threadName = String.format("%d.bt.net.pool.incoming-acceptor", config.getAcceptorPort());
         this.executor = Executors.newFixedThreadPool(
                 connectionAcceptors.size(),
-                CountingThreadFactory.factory("bt.net.pool.incoming-acceptor"));
+                CountingThreadFactory.factory(threadName));
     }
 
     public void startup() {

--- a/bt-core/src/main/java/bt/net/MessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/MessageDispatcher.java
@@ -66,7 +66,8 @@ public class MessageDispatcher implements IMessageDispatcher {
     private void initializeMessageLoop(IRuntimeLifecycleBinder lifecycleBinder,
                                        IPeerConnectionPool pool,
                                        Config config) {
-        ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "bt.net.message-dispatcher"));
+        String threadName = String.format("%d.bt.net.message-dispatcher", config.getAcceptorPort());
+        ExecutorService executor = Executors.newSingleThreadExecutor(r -> new Thread(r, threadName));
         LoopControl loopControl = new LoopControl(config.getMaxMessageProcessingInterval().toMillis());
         MessageDispatchingLoop loop = new MessageDispatchingLoop(pool, loopControl);
         lifecycleBinder.onStartup("Initialize message dispatcher", () -> executor.execute(loop));

--- a/bt-core/src/main/java/bt/net/PeerConnectionPool.java
+++ b/bt-core/src/main/java/bt/net/PeerConnectionPool.java
@@ -197,6 +197,9 @@ public class PeerConnectionPool implements IPeerConnectionPool {
     private List<PeerConnection> getConnectionsForAddress(TorrentId torrentId, Peer peer) {
         List<PeerConnection> connectionsWithSameAddress = new ArrayList<>();
         connections.visitConnections(torrentId, connection -> {
+            if (connection.isClosed()) {
+                return;
+            }
             Peer connectionPeer = connection.getRemotePeer();
             if (connectionPeer.getInetAddress().equals(peer.getInetAddress())) {
                 connectionsWithSameAddress.add(connection);

--- a/bt-core/src/main/java/bt/peer/TrackerPeerSourceFactory.java
+++ b/bt-core/src/main/java/bt/peer/TrackerPeerSourceFactory.java
@@ -47,7 +47,8 @@ class TrackerPeerSourceFactory implements PeerSourceFactory {
     public TrackerPeerSourceFactory(ITrackerService trackerService,
                                     TorrentRegistry torrentRegistry,
                                     IRuntimeLifecycleBinder lifecycleBinder,
-                                    Duration trackerQueryInterval) {
+                                    Duration trackerQueryInterval,
+                                    int port) {
         this.trackerService = trackerService;
         this.torrentRegistry = torrentRegistry;
         this.trackerQueryInterval = trackerQueryInterval;
@@ -58,7 +59,7 @@ class TrackerPeerSourceFactory implements PeerSourceFactory {
 
             @Override
             public Thread newThread(Runnable r) {
-                return new Thread(r, "bt.peer.tracker-peer-source-" + i.incrementAndGet());
+                return new Thread(r, String.format("%d.bt.peer.tracker-peer-source-%d", port, i.incrementAndGet()));
             }
         });
         lifecycleBinder.onShutdown("Shutdown tracker peer sources", executor::shutdownNow);

--- a/bt-core/src/main/java/bt/peer/lan/LocalServiceDiscoveryService.java
+++ b/bt-core/src/main/java/bt/peer/lan/LocalServiceDiscoveryService.java
@@ -148,6 +148,7 @@ public class LocalServiceDiscoveryService implements ILocalServiceDiscoveryServi
         int k = config.getLocalServiceDiscoveryMaxTorrentsPerAnnounce();
         List<TorrentId> ids = new ArrayList<>(k * 2);
         Iterator<TorrentId> iter = announceQueue.iterator();
+        List<TorrentId> toAdd = new ArrayList<>();
         while (iter.hasNext()) {
             TorrentId id = iter.next();
             StatusChange statusChange = statusChanges.get(id);
@@ -155,7 +156,7 @@ public class LocalServiceDiscoveryService implements ILocalServiceDiscoveryServi
                 if (ids.size() < k) {
                     iter.remove(); // temporary remove from the queue
                     ids.add(id);
-                    announceQueue.add(id); // add to the end of the queue
+                    toAdd.add(id); // add to the end of the queue
                 }
             } else if (statusChange == StatusChange.STOPPED) {
                 // remove inactive
@@ -164,6 +165,7 @@ public class LocalServiceDiscoveryService implements ILocalServiceDiscoveryServi
             // last case is that the torrent has been stopped and started in between the announces,
             // which means that we should leave it in the announce queue
         }
+        announceQueue.addAll(toAdd);
         // add all new started torrents to the announce queue
         statusChanges.forEach((id, statusChange) -> {
             if (statusChange == StatusChange.STARTED) {

--- a/bt-core/src/main/java/bt/runtime/BtRuntime.java
+++ b/bt-core/src/main/java/bt/runtime/BtRuntime.java
@@ -93,7 +93,8 @@ public class BtRuntime {
     private boolean manualShutdownOnly;
 
     BtRuntime(Injector injector, Config config) {
-        Runtime.getRuntime().addShutdownHook(new Thread("bt.runtime.shutdown-manager") {
+        String threadName = String.format("%d.bt.runtime.shutdown-manager", config.getAcceptorPort());
+        Runtime.getRuntime().addShutdownHook(new Thread(threadName) {
             @Override
             public void run() {
                 shutdown();
@@ -280,7 +281,8 @@ public class BtRuntime {
     private ExecutorService createLifecycleExecutor(LifecycleEvent event) {
         AtomicInteger threadCount = new AtomicInteger();
         return Executors.newCachedThreadPool(r -> {
-            Thread t = new Thread(r, "bt.runtime." + event.name().toLowerCase() + "-worker-" + threadCount.incrementAndGet());
+            String threadName = String.format("%d.bt.runtime.%s.worker-%d", config.getAcceptorPort(), event.name().toLowerCase(), threadCount.incrementAndGet());
+            Thread t = new Thread(r, threadName);
             t.setDaemon(true);
             return t;
         });

--- a/bt-core/src/main/java/bt/service/ExecutorServiceProvider.java
+++ b/bt-core/src/main/java/bt/service/ExecutorServiceProvider.java
@@ -16,6 +16,7 @@
 
 package bt.service;
 
+import bt.runtime.Config;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -32,10 +33,12 @@ public class ExecutorServiceProvider implements Provider<ExecutorService> {
 
     private volatile ExecutorService executorService;
     private final Object lock;
+    private final Config config;
 
     @Inject
-    public ExecutorServiceProvider() {
-        lock = new Object();
+    public ExecutorServiceProvider(Config config) {
+        this.lock = new Object();
+        this.config = config;
     }
 
     @Override
@@ -64,6 +67,6 @@ public class ExecutorServiceProvider implements Provider<ExecutorService> {
      * @since 1.6
      */
     protected String getNamePrefix() {
-        return "bt.service.executor-thread";
+        return String.format("%d.bt.service.executor-thread", config.getAcceptorPort());
     }
 }

--- a/bt-core/src/main/java/bt/torrent/data/DefaultDataWorker.java
+++ b/bt-core/src/main/java/bt/torrent/data/DefaultDataWorker.java
@@ -22,6 +22,7 @@ import bt.data.DataDescriptor;
 import bt.metainfo.TorrentId;
 import bt.net.Peer;
 import bt.net.buffer.BufferedData;
+import bt.runtime.Config;
 import bt.service.IRuntimeLifecycleBinder;
 import bt.torrent.TorrentRegistry;
 import org.slf4j.Logger;
@@ -51,7 +52,7 @@ public class DefaultDataWorker implements DataWorker {
                              TorrentRegistry torrentRegistry,
                              ChunkVerifier verifier,
                              BlockCache blockCache,
-                             int maxQueueLength) {
+                             Config config) {
 
         this.torrentRegistry = torrentRegistry;
         this.verifier = verifier;
@@ -63,10 +64,10 @@ public class DefaultDataWorker implements DataWorker {
 
             @Override
             public Thread newThread(Runnable r) {
-                return new Thread(r, "bt.torrent.data.worker-" + i.incrementAndGet());
+                return new Thread(r, String.format("%d.bt.torrent.data.worker-%d", config.getAcceptorPort(), i.incrementAndGet()));
             }
         });
-        this.maxPendingTasks = maxQueueLength;
+        this.maxPendingTasks = config.getMaxIOQueueSize();
         this.pendingTasksCount = new AtomicInteger();
 
         lifecycleBinder.onShutdown("Shutdown data worker", this.executor::shutdownNow);

--- a/bt-core/src/main/java/bt/tracker/udp/UdpMessageWorker.java
+++ b/bt-core/src/main/java/bt/tracker/udp/UdpMessageWorker.java
@@ -59,12 +59,14 @@ class UdpMessageWorker {
 
     public UdpMessageWorker(SocketAddress localAddress,
                             SocketAddress remoteAddress,
-                            IRuntimeLifecycleBinder lifecycleBinder) {
+                            IRuntimeLifecycleBinder lifecycleBinder,
+                            int listeningPort) {
         this.localAddress = localAddress;
         this.remoteAddress = remoteAddress;
         this.lock = new Object();
 
-        this.executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "bt.tracker.udp.message-worker"));
+        String threadName = String.format("%d.bt.tracker.udp.message-worker", listeningPort);
+        this.executor = Executors.newSingleThreadExecutor(r -> new Thread(r, threadName));
         lifecycleBinder.onShutdown("Shutdown UDP message worker", () -> {
             try {
                 this.shutdown();

--- a/bt-core/src/main/java/bt/tracker/udp/UdpTracker.java
+++ b/bt-core/src/main/java/bt/tracker/udp/UdpTracker.java
@@ -65,7 +65,7 @@ class UdpTracker implements Tracker {
         this.numberOfPeersToRequestFromTracker = numberOfPeersToRequestFromTracker;
         // TODO: one UDP socket for all outgoing tracker connections
         this.trackerUrl = toUrl(trackerUrl);
-        this.worker = new UdpMessageWorker(new InetSocketAddress(localAddress, 0), getSocketAddress(this.trackerUrl), lifecycleBinder);
+        this.worker = new UdpMessageWorker(new InetSocketAddress(localAddress, 0), getSocketAddress(this.trackerUrl), lifecycleBinder, listeningPort);
     }
 
     private URL toUrl(String s) {

--- a/bt-dht/bt-dht/src/main/java/bt/dht/DHTPeerSourceFactory.java
+++ b/bt-dht/bt-dht/src/main/java/bt/dht/DHTPeerSourceFactory.java
@@ -19,6 +19,7 @@ package bt.dht;
 import bt.metainfo.TorrentId;
 import bt.peer.PeerSource;
 import bt.peer.PeerSourceFactory;
+import bt.runtime.Config;
 import bt.service.IRuntimeLifecycleBinder;
 import com.google.inject.Inject;
 
@@ -41,9 +42,11 @@ public class DHTPeerSourceFactory implements PeerSourceFactory {
 
     @Inject
     public DHTPeerSourceFactory(IRuntimeLifecycleBinder lifecycleBinder,
-                                DHTService dhtService) {
+                                DHTService dhtService,
+                                Config config) {
         this.dhtService = dhtService;
-        this.executor = Executors.newCachedThreadPool(r -> new Thread(r, "bt.dht.executor"));
+        String threadName = String.format("%d.bt.dht.executor", config.getAcceptorPort());
+        this.executor = Executors.newCachedThreadPool(r -> new Thread(r, threadName));
         lifecycleBinder.onShutdown("Shutdown DHT peer sources", executor::shutdownNow);
 
         this.peerSources = new ConcurrentHashMap<>();

--- a/bt-tests/src/main/java/bt/it/fixture/TestExecutorServiceProvider.java
+++ b/bt-tests/src/main/java/bt/it/fixture/TestExecutorServiceProvider.java
@@ -29,6 +29,7 @@ public class TestExecutorServiceProvider extends ExecutorServiceProvider {
 
     @Inject
     public TestExecutorServiceProvider(Config config) {
+        super(config);
         this.prefix = String.format(PREFIX_FORMAT, getLiteralIP(config.getAcceptorAddress()), config.getAcceptorPort());
     }
 

--- a/bt-tests/src/test/java/bt/tracker/udp/UdpTrackerConnection.java
+++ b/bt-tests/src/test/java/bt/tracker/udp/UdpTrackerConnection.java
@@ -34,7 +34,7 @@ public class UdpTrackerConnection extends ExternalResource {
 
     public UdpTrackerConnection(SingleClientUdpTracker tracker) {
         InetSocketAddress localAddress = new InetSocketAddress(Inet4Address.getLoopbackAddress(), 0);
-        this.worker = new UdpMessageWorker(localAddress, tracker.getServerAddress(), mock(IRuntimeLifecycleBinder.class));
+        this.worker = new UdpMessageWorker(localAddress, tracker.getServerAddress(), mock(IRuntimeLifecycleBinder.class), 0);
         LOGGER.info("Established connection (local: {}, remote: {}", localAddress, tracker.getServerAddress());
     }
 


### PR DESCRIPTION
when one host create more than one BtRuntimes, thread names between runtimes are same, we need using acceptor port to distinguish them from each other.   
