### PR TITLE
Implement LRU cache for open File Handles for Torrents with many files

### DIFF
--- a/bt-core/src/main/java/bt/TorrentClientBuilder.java
+++ b/bt-core/src/main/java/bt/TorrentClientBuilder.java
@@ -268,6 +268,11 @@ public class TorrentClientBuilder<B extends TorrentClientBuilder> extends BaseCl
             listenerSource.addListener(ProcessingEvent.FILES_CHOSEN, listener);
         }
 
+        listenerSource.addListener(ProcessingEvent.DOWNLOAD_COMPLETE, (context, next) -> {
+            context.getStorage().flush();
+            return next;
+        });
+
         if (stopWhenDownloaded) {
             listenerSource.addListener(ProcessingEvent.DOWNLOAD_COMPLETE, (context, next) -> null);
         }

--- a/bt-core/src/main/java/bt/data/DefaultDataDescriptor.java
+++ b/bt-core/src/main/java/bt/data/DefaultDataDescriptor.java
@@ -93,13 +93,9 @@ class DefaultDataDescriptor implements DataDescriptor {
             if (unit.capacity() > 0) {
                 nonEmptyStorageUnits.add(unit);
             } else {
-                try {
-                    // TODO: think about adding some explicit "initialization/creation" method
-                    if (unit.writeBlock(new byte[0], 0) < 0) {
-                        throw new IllegalStateException("Failed to initialize storage unit: " + unit);
-                    }
-                } catch (Exception e) {
-                    LOGGER.warn("Failed to create empty storage unit: " + unit, e);
+                // TODO: think about adding some explicit "initialization/creation" method
+                if (unit.writeBlock(new byte[0], 0) < 0) {
+                    throw new IllegalStateException("Failed to initialize storage unit: " + unit);
                 }
             }
         }

--- a/bt-core/src/main/java/bt/data/ReadWriteDataRange.java
+++ b/bt-core/src/main/java/bt/data/ReadWriteDataRange.java
@@ -18,6 +18,8 @@ package bt.data;
 
 import bt.net.buffer.ByteBufferView;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/bt-core/src/main/java/bt/data/Storage.java
+++ b/bt-core/src/main/java/bt/data/Storage.java
@@ -35,4 +35,9 @@ public interface Storage {
      * @since 1.0
      */
     StorageUnit getUnit(Torrent torrent, TorrentFile torrentFile);
+
+    /**
+     * Flushes any buffered data in this storage backend
+     */
+    void flush();
 }

--- a/bt-core/src/main/java/bt/data/StorageUnit.java
+++ b/bt-core/src/main/java/bt/data/StorageUnit.java
@@ -42,7 +42,6 @@ public interface StorageUnit extends Closeable {
      *               the maximum number of bytes to read.
      * @param offset Index to start reading from (0-based)
      * @return Actual number of bytes read
-     *
      * @since 1.0
      */
     int readBlock(ByteBuffer buffer, long offset);
@@ -50,7 +49,13 @@ public interface StorageUnit extends Closeable {
     /**
      * @since 1.9
      */
-    void readBlockFully(ByteBuffer buffer, long offset);
+    default void readBlockFully(ByteBuffer buffer, long offset) {
+        int read = 0, total = 0;
+        do {
+            total += read;
+            read = readBlock(buffer, offset + total);
+        } while (read >= 0 && buffer.hasRemaining());
+    }
 
     /**
      * Try to read a block of data into the provided array, starting with a given offset.
@@ -64,7 +69,6 @@ public interface StorageUnit extends Closeable {
      *               Array's length determines the maximum number of bytes to read.
      * @param offset Index to starting reading from (0-based)
      * @return Actual number of bytes read
-     *
      * @since 1.0
      */
     default int readBlock(byte[] buffer, long offset) {
@@ -84,7 +88,6 @@ public interface StorageUnit extends Closeable {
      *               the maximum number of bytes to write.
      * @param offset Offset in this storage's data to start writing to (0-based)
      * @return Actual number of bytes written
-     *
      * @since 1.0
      */
     int writeBlock(ByteBuffer buffer, long offset);
@@ -92,7 +95,13 @@ public interface StorageUnit extends Closeable {
     /**
      * @since 1.9
      */
-    void writeBlockFully(ByteBuffer buffer, long offset);
+    default void writeBlockFully(ByteBuffer buffer, long offset) {
+        int written = 0, total = 0;
+        do {
+            total += written;
+            written = writeBlock(buffer, offset + total);
+        } while (written >= 0 && buffer.hasRemaining());
+    }
 
     /**
      * Try to write a block of data from the provided buffer to this storage, starting with a given offset.
@@ -107,7 +116,6 @@ public interface StorageUnit extends Closeable {
      *               the maximum number of bytes to write.
      * @param offset Offset in this storage's data to start writing to (0-based)
      * @return Actual number of bytes written
-     *
      * @since 1.9
      */
     int writeBlock(ByteBufferView buffer, long offset);
@@ -115,7 +123,13 @@ public interface StorageUnit extends Closeable {
     /**
      * @since 1.9
      */
-    void writeBlockFully(ByteBufferView buffer, long offset);
+    default void writeBlockFully(ByteBufferView buffer, long offset) {
+        int written = 0, total = 0;
+        do {
+            total += written;
+            written = writeBlock(buffer, offset + total);
+        } while (written >= 0 && buffer.hasRemaining());
+    }
 
     /**
      * Try to write a block of data to this storage, starting with a given offset.
@@ -129,7 +143,6 @@ public interface StorageUnit extends Closeable {
      *              Block's length determines the maximum number of bytes to write.
      * @param offset Offset in this storage's data to start writing to (0-based)
      * @return Actual number of bytes written
-     *
      * @since 1.0
      */
     default int writeBlock(byte[] block, long offset) {

--- a/bt-core/src/main/java/bt/data/file/CachedOpenFile.java
+++ b/bt-core/src/main/java/bt/data/file/CachedOpenFile.java
@@ -1,0 +1,168 @@
+package bt.data.file;
+
+import bt.data.StorageUnit;
+import bt.net.buffer.ByteBufferView;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * A file that is kept open so reads/writes to the file do not incur the costs of opening and closing a file
+ */
+class CachedOpenFile implements StorageUnit {
+    /**
+     * the channel of the open file
+     */
+    private final FileChannel fc;
+    /**
+     * A read write lock for file operations to ensure we don't close a channel in the middle of an operation
+     */
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+    /**
+     * The capacity of this file when downloaded. Used for more information on exception cases
+     */
+    private final long capacity;
+
+    /**
+     * Open the specified cache file
+     *
+     * @param file     the file to open
+     * @param capacity the capacity of the file
+     */
+    CachedOpenFile(Path file, long capacity) {
+        try {
+            file.getParent().toFile().mkdirs(); // ensure parent directory exists
+            // open the file for reading and writing, create it if it isn't present
+            fc = FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
+        } catch (IOException ex) {
+            throw new UncheckedIOException("Could not open file " + file.toAbsolutePath(), ex);
+        }
+        this.capacity = capacity;
+    }
+
+    @Override
+    public int readBlock(ByteBuffer buffer, long offset) {
+        ensureOpen();
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Negative offset: " + offset);
+        } else if (offset > capacity - buffer.remaining()) {
+            throw new IllegalArgumentException("Received a request to read past the end of file (offset: " + offset +
+                    ", requested block length: " + buffer.remaining() + ", file capacity: " + capacity);
+        }
+
+        try {
+            return fc.read(buffer, offset);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read bytes (offset: " + offset +
+                    ", requested block length: " + buffer.remaining() + ", file capacity: " + capacity + ")", e);
+        }
+    }
+
+    @Override
+    public int writeBlock(ByteBuffer buffer, long offset) {
+        ensureOpen();
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Negative offset: " + offset);
+        } else if (offset > capacity - buffer.remaining()) {
+            throw new IllegalArgumentException("Received a request to write past the end of file (offset: " + offset +
+                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity);
+        }
+
+        try {
+            return fc.write(buffer, offset);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write bytes (offset: " + offset +
+                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity + ")", e);
+        }
+    }
+
+    @Override
+    public int writeBlock(ByteBufferView buffer, long offset) {
+        ensureOpen();
+
+        if (offset < 0) {
+            throw new IllegalArgumentException("Negative offset: " + offset);
+        } else if (offset > capacity - buffer.remaining()) {
+            throw new IllegalArgumentException("Received a request to write past the end of file (offset: " + offset +
+                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity);
+        }
+
+        try {
+            return buffer.transferTo(fc, offset);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to write bytes (offset: " + offset +
+                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity + ")", e);
+        }
+    }
+
+    @Override
+    public long capacity() {
+        return capacity;
+    }
+
+    @Override
+    public long size() {
+        ensureOpen();
+        try {
+            return fc.size();
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+    }
+
+    /**
+     * Flush any changes to the file to disk. Does not flush metadata
+     *
+     * @throws IOException on failure to flush
+     */
+    public void flush() throws IOException {
+        // if it was already closed, it was already flushed.
+        if (fc.isOpen())
+            this.fc.force(false);
+    }
+
+    /**
+     * Lock this file for an IO Operation. This prevents a potential race condition where the file could be closed
+     * while a write operation occurs
+     */
+    public void lockForIoOperation() {
+        this.lock.readLock().lock();
+    }
+
+    /**
+     * Unlock the file as the operation has completed
+     */
+    public void unlockForIoOperation() {
+        this.lock.readLock().unlock();
+    }
+
+    /**
+     * Close any allocated resources for this file.
+     *
+     * @throws IOException on failure to close the file
+     */
+    @Override
+    public void close() throws IOException {
+        // wait for any reads to finish
+        lock.writeLock().lock();
+        try {
+            this.fc.close();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    private void ensureOpen() {
+        if (!fc.isOpen()) {
+            throw new IllegalStateException("Cannot access a closed file.");
+        }
+    }
+}

--- a/bt-core/src/main/java/bt/data/file/CachedOpenFile.java
+++ b/bt-core/src/main/java/bt/data/file/CachedOpenFile.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -37,7 +38,7 @@ class CachedOpenFile implements StorageUnit {
      */
     CachedOpenFile(Path file, long capacity) {
         try {
-            file.getParent().toFile().mkdirs(); // ensure parent directory exists
+            Files.createDirectories(file.getParent()); // ensure parent directory exists
             // open the file for reading and writing, create it if it isn't present
             fc = FileChannel.open(file, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE);
         } catch (IOException ex) {

--- a/bt-core/src/main/java/bt/data/file/FileCacheKey.java
+++ b/bt-core/src/main/java/bt/data/file/FileCacheKey.java
@@ -1,0 +1,57 @@
+package bt.data.file;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * The key for a file that can have a handle open and cached for it. This object implements hashCode() and equals()
+ * Quickly and efficiently.
+ */
+public class FileCacheKey {
+    private final String pathKey;
+    private final Path file;
+    private final long capacity;
+
+    /**
+     * Construct a new File Cache Key
+     *
+     * @param file     an absolute path to the file
+     * @param capacity the capacity of the file
+     */
+    public FileCacheKey(Path file, long capacity) {
+        this.pathKey = file.toAbsolutePath().toString();
+        this.file = file;
+        this.capacity = capacity;
+    }
+
+    /**
+     * Get the file that this key represents
+     *
+     * @return the file that this key represents
+     */
+    public Path getFile() {
+        return file;
+    }
+
+    /**
+     * Get the capacity of this file
+     *
+     * @return the capacity of this file
+     */
+    public long getCapacity() {
+        return capacity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileCacheKey that = (FileCacheKey) o;
+        return pathKey.equals(that.pathKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pathKey);
+    }
+}

--- a/bt-core/src/main/java/bt/data/file/FileSystemStorageUnit.java
+++ b/bt-core/src/main/java/bt/data/file/FileSystemStorageUnit.java
@@ -27,158 +27,57 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 class FileSystemStorageUnit implements StorageUnit {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemStorageUnit.class);
 
+    private final OpenFileCache cache;
+    private final FileCacheKey key;
     private Path parent, file;
     private SeekableByteChannel sbc;
-    private long capacity;
+    private final long capacity;
 
-    private volatile boolean closed;
-
-    FileSystemStorageUnit(Path root, String path, long capacity) {
+    FileSystemStorageUnit(OpenFileCache cache, Path root, String path, long capacity) {
+        this.cache = cache;
         this.file = root.resolve(path);
         this.parent = file.getParent();
+        this.key = new FileCacheKey(file, capacity);
         this.capacity = capacity;
-        this.closed = true;
-    }
-
-    // TODO: this is temporary fix for verification upon app start
-    // should be re-done (probably need additional API to know if storage unit is "empty")
-    private boolean init(boolean create) {
-        if (closed) {
-            if (!Files.exists(file)) {
-                if (create) {
-                    if (!Files.exists(parent)) {
-                        try {
-                            Files.createDirectories(parent);
-                        } catch (IOException e) {
-                            throw new UncheckedIOException("Failed to create file storage -- can't create (some of the) directories", e);
-                        }
-                    }
-
-                    try {
-                        Files.createFile(file);
-                    } catch (IOException e) {
-                        throw new UncheckedIOException("Failed to create file storage -- " +
-                                "can't create new file: " + file.toAbsolutePath(), e);
-                    }
-                } else {
-                    return false;
-                }
-            }
-
-            try {
-                sbc = Files.newByteChannel(file, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.DSYNC);
-            } catch (IOException e) {
-                throw new UncheckedIOException("Unexpected I/O error", e);
-            }
-
-            closed = false;
-        }
-        return true;
     }
 
     @Override
-    public synchronized int readBlock(ByteBuffer buffer, long offset) {
-        if (closed) {
-            if (!init(false)) {
-                return -1;
-            }
+    public int readBlock(ByteBuffer buffer, long offset) {
+        if (!cache.existsOnFileSystem(key)) {
+            return -1;
         }
 
-        if (offset < 0) {
-            throw new IllegalArgumentException("Negative offset: " + offset);
-        } else if (offset > capacity - buffer.remaining()) {
-            throw new IllegalArgumentException("Received a request to read past the end of file (offset: " + offset +
-                    ", requested block length: " + buffer.remaining() + ", file capacity: " + capacity);
-        }
-
-        try {
-            sbc.position(offset);
-            return sbc.read(buffer);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to read bytes (offset: " + offset +
-                    ", requested block length: " + buffer.remaining() + ", file capacity: " + capacity + ")", e);
-        }
+        return cache.readBlock(key, buffer, offset);
     }
 
     @Override
-    public synchronized void readBlockFully(ByteBuffer buffer, long offset) {
-        int read = 0, total = 0;
-        do {
-            total += read;
-            read = readBlock(buffer, offset + total);
-        } while (read >= 0 && buffer.hasRemaining());
+    public void readBlockFully(ByteBuffer buffer, long offset) {
+        cache.readBlockFully(key, buffer, offset);
     }
 
     @Override
-    public synchronized int writeBlock(ByteBuffer buffer, long offset) {
-        if (closed) {
-            if (!init(true)) {
-                return -1;
-            }
-        }
-
-        if (offset < 0) {
-            throw new IllegalArgumentException("Negative offset: " + offset);
-        } else if (offset > capacity - buffer.remaining()) {
-            throw new IllegalArgumentException("Received a request to write past the end of file (offset: " + offset +
-                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity);
-        }
-
-        try {
-            sbc.position(offset);
-            return sbc.write(buffer);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write bytes (offset: " + offset +
-                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity + ")", e);
-        }
+    public int writeBlock(ByteBuffer buffer, long offset) {
+        return cache.writeBlock(key, buffer, offset);
     }
 
     @Override
-    public synchronized void writeBlockFully(ByteBuffer buffer, long offset) {
-        int written = 0, total = 0;
-        do {
-            total += written;
-            written = writeBlock(buffer, offset + total);
-        } while (written >= 0 && buffer.hasRemaining());
+    public void writeBlockFully(ByteBuffer buffer, long offset) {
+        cache.writeBlockFully(key, buffer, offset);
     }
 
     @Override
-    public synchronized int writeBlock(ByteBufferView buffer, long offset) {
-        if (closed) {
-            if (!init(true)) {
-                return -1;
-            }
-        }
-
-        if (offset < 0) {
-            throw new IllegalArgumentException("Negative offset: " + offset);
-        } else if (offset > capacity - buffer.remaining()) {
-            throw new IllegalArgumentException("Received a request to write past the end of file (offset: " + offset +
-                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity);
-        }
-
-        try {
-            sbc.position(offset);
-            return buffer.transferTo(sbc);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to write bytes (offset: " + offset +
-                    ", block length: " + buffer.remaining() + ", file capacity: " + capacity + ")", e);
-        }
+    public int writeBlock(ByteBufferView buffer, long offset) {
+        return this.cache.writeBlock(key, buffer, offset);
     }
 
     @Override
-    public synchronized void writeBlockFully(ByteBufferView buffer, long offset) {
-        int written = 0, total = 0;
-        do {
-            total += written;
-            written = writeBlock(buffer, offset + total);
-        } while (written >= 0 && buffer.hasRemaining());
+    public void writeBlockFully(ByteBufferView buffer, long offset) {
+        this.cache.writeBlockFully(key, buffer, offset);
     }
 
     @Override
@@ -201,15 +100,7 @@ class FileSystemStorageUnit implements StorageUnit {
     }
 
     @Override
-    public void close() {
-        if (!closed) {
-            try {
-                sbc.close();
-            } catch (IOException e) {
-                LOGGER.warn("Failed to close file: " + file, e);
-            } finally {
-                closed = true;
-            }
-        }
+    public void close() throws IOException{
+        cache.close(key);
     }
 }

--- a/bt-core/src/main/java/bt/data/file/OpenFileCache.java
+++ b/bt-core/src/main/java/bt/data/file/OpenFileCache.java
@@ -1,0 +1,252 @@
+package bt.data.file;
+
+import bt.net.buffer.ByteBufferView;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * This is an LRU cache for open files. It prevents having too many opened files by limiting the total possible opened
+ * while minimizing file open/close operation by keeping recently read/written files open.
+ */
+public class OpenFileCache {
+    private static final float LOAD_FACTOR = .75f;
+    // maps normalized file name to a storage unit for the file
+    private final LinkedHashMap<FileCacheKey, CachedOpenFile> cache;
+
+    /**
+     * Construct an LRU cache for managing open files
+     *
+     * @param maxOpenFiles the max number of permitted open files
+     */
+    public OpenFileCache(int maxOpenFiles) {
+        cache = new SizeLimitedFileCache(maxOpenFiles);
+    }
+
+    /**
+     * Read a block from the provided file cache key
+     *
+     * @param key    the key that references the files to read the block for
+     * @param buffer the buffer to read the block into
+     * @param offset the offset of the block
+     * @return the number of bytes read.
+     */
+    public int readBlock(FileCacheKey key, ByteBuffer buffer, long offset) {
+        return runOperationOnOpenFile(key, cof -> cof.readBlock(buffer, offset));
+    }
+
+    /**
+     * Fully read a block from the provided file cache key
+     *
+     * @param key    the key that references the files to read the block for
+     * @param buffer the buffer to read the block into
+     * @param offset the offset of the block
+     */
+    public void readBlockFully(FileCacheKey key, ByteBuffer buffer, long offset) {
+        runOperationOnOpenFileConsumer(key, cof -> cof.readBlockFully(buffer, offset));
+    }
+
+    /**
+     * Write a block to the provided file cache key
+     *
+     * @param key    the key that references the files to write the block for
+     * @param buffer the buffer to write the block into
+     * @param offset the offset of the block
+     * @return the number of bytes writen.
+     */
+    public int writeBlock(FileCacheKey key, ByteBuffer buffer, long offset) {
+        return runOperationOnOpenFile(key, cof -> cof.writeBlock(buffer, offset));
+    }
+
+    /**
+     * Fully write a block from the provided file cache key
+     *
+     * @param key    the key that references the files to write the block for
+     * @param buffer the buffer to write the block into
+     * @param offset the offset of the block
+     */
+    public void writeBlockFully(FileCacheKey key, ByteBuffer buffer, long offset) {
+        runOperationOnOpenFileConsumer(key, cof -> cof.writeBlockFully(buffer, offset));
+    }
+
+    /**
+     * Write a block to the provided file cache key
+     *
+     * @param key    the key that references the files to write the block for
+     * @param buffer the buffer to write the block into
+     * @param offset the offset of the block
+     * @return the number of bytes writen.
+     */
+    public int writeBlock(FileCacheKey key, ByteBufferView buffer, long offset) {
+        return runOperationOnOpenFile(key, cof -> cof.writeBlock(buffer, offset));
+    }
+
+    /**
+     * Fully write a block from the provided file cache key
+     *
+     * @param key    the key that references the files to write the block for
+     * @param buffer the buffer to write the block into
+     * @param offset the offset of the block
+     */
+    public void writeBlockFully(FileCacheKey key, ByteBufferView buffer, long offset) {
+        runOperationOnOpenFileConsumer(key, cof -> cof.writeBlockFully(buffer, offset));
+    }
+
+    /**
+     * Get the size of the file referred to by key on disk
+     * @param key the key of the file
+     * @return the size of the file on disk
+     */
+    public long size(FileCacheKey key) {
+        return runOperationOnOpenFile(key, cof -> cof.size());
+    }
+
+    /**
+     * Flush all buffered data to the file system
+     */
+    public void flush() {
+        List<CachedOpenFile> openedFiles = null;
+        // So we don't globally block writes while flushing, we copy the currently open files and flush them.
+        synchronized (this) {
+            openedFiles = new ArrayList<>(cache.values());
+        }
+
+        for (CachedOpenFile openFile : openedFiles) {
+            openFile.lockForIoOperation();
+            try {
+                // this file may have been closed between when we copied the cache values and when we call flush.
+                // That's OK - flush handles this.
+                openFile.flush();
+            } catch (IOException ex) {
+                throw new UncheckedIOException("Could not flush file to disk.", ex);
+            } finally {
+                openFile.unlockForIoOperation();
+            }
+        }
+    }
+
+    /**
+     * Check if the the File exists on the file system. First checks if the file system exists in the cache. If yes,
+     * the file definitely exists and returns true. If not, it checks the filesystem if the file exists.
+     *
+     * @param key the key to check whether exists on the file system
+     * @return true if it exists on the filesystem, false otherwise
+     */
+    public boolean existsOnFileSystem(FileCacheKey key) {
+        synchronized (this) {
+            if (cache.containsKey(key))
+                return true;
+        }
+        return Files.exists(key.getFile());
+    }
+
+    /**
+     * Run a consumer operation on a file. This function is for convenience
+     *
+     * @param key       the key of the file to run the operation on
+     * @param operation the consumer operation to run
+     */
+    private void runOperationOnOpenFileConsumer(FileCacheKey key, Consumer<CachedOpenFile> operation) {
+        runOperationOnOpenFile(key, cof -> {
+            operation.accept(cof);
+            return null;
+        });
+    }
+
+    /**
+     * Run an consumer operation on a file. This function handles locking to ensure that the operation is safely run
+     *
+     * @param key       the key of the file to run the operation on
+     * @param operation the operation to run
+     * @return the result of the operation
+     */
+    private <T> T runOperationOnOpenFile(FileCacheKey key, Function<CachedOpenFile, T> operation) {
+        CachedOpenFile operationFile = null;
+        boolean gotLock = false;
+        try {
+            synchronized (this) {
+                operationFile = cache.computeIfAbsent(key, k -> new CachedOpenFile(k.getFile(), k.getCapacity()));
+                // get lock in synchronized block to ensure closed cannot be called by another thread before we get the read lock
+                operationFile.lockForIoOperation();
+                gotLock = true;
+            }
+            return operation.apply(operationFile);
+        } finally {
+            if (gotLock)
+                operationFile.unlockForIoOperation();
+        }
+    }
+
+    /**
+     * Close the file associated with this cache key if it is open
+     *
+     * @param key the key of the file to close
+     * @throws IOException on failure to close
+     */
+    public void close(FileCacheKey key) throws IOException {
+        CachedOpenFile closed;
+        synchronized (this) {
+            closed = cache.remove(key);
+            // This is in the synchronized block on purpose to avoid closing while another thread tries to get a readlock
+            if (closed != null)
+                closed.close();
+        }
+    }
+
+    /**
+     * Close all open files in this storage system.
+     *
+     * @throws IOException on failure to close file
+     */
+    public synchronized void close() throws IOException {
+        Iterator<Map.Entry<FileCacheKey, CachedOpenFile>> it = this.cache.entrySet().iterator();
+        IOException toThrow = null;
+        while (it.hasNext()) {
+            CachedOpenFile openFileCache = it.next().getValue();
+            it.remove();
+            try {
+                openFileCache.close();
+            } catch (IOException ex) {
+                if (toThrow != null)
+                    ex.printStackTrace();
+                toThrow = ex;
+            }
+        }
+        if (null != toThrow)
+            throw toThrow;
+    }
+
+    /**
+     * A size limited cache for open files to avoid excessive open/close calls.
+     */
+    static class SizeLimitedFileCache extends LinkedHashMap<FileCacheKey, CachedOpenFile> {
+        private final int maxOpenFiles;
+
+        public SizeLimitedFileCache(int maxOpenFiles) {
+            super((int) Math.ceil(maxOpenFiles / LOAD_FACTOR), LOAD_FACTOR, true);
+            this.maxOpenFiles = maxOpenFiles;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<FileCacheKey, CachedOpenFile> eldest) {
+            if (size() >= maxOpenFiles) {
+                try {
+                    eldest.getValue().close();
+                } catch (IOException ex) {
+                    throw new UncheckedIOException("Failed to close file", ex);
+                }
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/bt-core/src/main/java/bt/net/buffer/ByteBufferView.java
+++ b/bt-core/src/main/java/bt/net/buffer/ByteBufferView.java
@@ -18,7 +18,7 @@ package bt.net.buffer;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
+import java.nio.channels.FileChannel;
 
 public interface ByteBufferView {
 
@@ -46,7 +46,15 @@ public interface ByteBufferView {
 
     void transferTo(ByteBuffer buffer);
 
-    int transferTo(WritableByteChannel sbc) throws IOException;
+    /**
+     * Transfer the contents of this byte buffer view to the file channel passed in. Does not change the position of the
+     * file channel
+     * @param fc the file channel
+     * @param offset the offset in the file channel
+     * @return the number of byte transferred to the filechannel
+     * @throws IOException on failure to write to the file channel
+     */
+    int transferTo(FileChannel fc, long offset) throws IOException;
 
     ByteBufferView duplicate();
 }

--- a/bt-core/src/main/java/bt/net/buffer/DelegatingByteBufferView.java
+++ b/bt-core/src/main/java/bt/net/buffer/DelegatingByteBufferView.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
 
 public class DelegatingByteBufferView implements ByteBufferView {
@@ -94,8 +95,8 @@ public class DelegatingByteBufferView implements ByteBufferView {
     }
 
     @Override
-    public int transferTo(WritableByteChannel sbc) throws IOException {
-        return sbc.write(delegate);
+    public int transferTo(FileChannel fc, long offset) throws IOException {
+        return fc.write(delegate, offset);
     }
 
     @Override

--- a/bt-core/src/main/java/bt/net/buffer/SplicedByteBufferView.java
+++ b/bt-core/src/main/java/bt/net/buffer/SplicedByteBufferView.java
@@ -22,7 +22,7 @@ import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.channels.WritableByteChannel;
+import java.nio.channels.FileChannel;
 
 public class SplicedByteBufferView implements ByteBufferView {
 
@@ -200,13 +200,13 @@ public class SplicedByteBufferView implements ByteBufferView {
     }
 
     @Override
-    public int transferTo(WritableByteChannel sbc) throws IOException {
+    public int transferTo(FileChannel fc, long offset) throws IOException {
         if (position < leftCapacity) {
-            int written = sbc.write(left);
+            int written = fc.write(left, offset);
             position += written;
             return written;
         } else if (limit > leftCapacity) {
-            int written = sbc.write(right);
+            int written = fc.write(right, offset);
             position += written;
             return written;
         }

--- a/bt-core/src/main/java/bt/peer/PeerRegistry.java
+++ b/bt-core/src/main/java/bt/peer/PeerRegistry.java
@@ -75,7 +75,7 @@ public class PeerRegistry implements IPeerRegistry {
                         Set<PeerSourceFactory> extraPeerSourceFactories,
                         Config config) {
 
-        this.localPeer = InetPeer.builder(config.getAcceptorAddress(), config.getAcceptorPort())
+        this.localPeer = InetPeer.builder(config.getPeerAddress().orElse(config.getAcceptorAddress()), config.getAcceptorPort())
                 .peerId(idService.getLocalPeerId())
                 .build();
 

--- a/bt-core/src/main/java/bt/processor/ProcessingContext.java
+++ b/bt-core/src/main/java/bt/processor/ProcessingContext.java
@@ -16,6 +16,7 @@
 
 package bt.processor;
 
+import bt.data.Storage;
 import bt.metainfo.Torrent;
 import bt.metainfo.TorrentId;
 import bt.torrent.TorrentSessionState;
@@ -47,4 +48,10 @@ public interface ProcessingContext {
      * @since 1.5
      */
     Optional<TorrentSessionState> getState();
+
+    /**
+     * @return Get the storage for this torrent
+     * @since 1.10
+     */
+    Storage getStorage();
 }

--- a/bt-core/src/main/java/bt/runtime/Config.java
+++ b/bt-core/src/main/java/bt/runtime/Config.java
@@ -22,6 +22,7 @@ import bt.service.NetworkUtil;
 
 import java.net.InetAddress;
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * Provides runtime configuration parameters.
@@ -31,6 +32,7 @@ import java.time.Duration;
 public class Config {
 
     private InetAddress acceptorAddress;
+    private Optional<InetAddress> peerAddress;
     private int acceptorPort;
     private Duration peerDiscoveryInterval;
     private Duration peerHandshakeTimeout;
@@ -69,6 +71,7 @@ public class Config {
      */
     public Config() {
         this.acceptorAddress = NetworkUtil.getInetAddressFromNetworkInterfaces();
+        this.peerAddress = Optional.empty();
         this.acceptorPort = 6891;
         this.peerDiscoveryInterval = Duration.ofSeconds(5);
         this.peerConnectionRetryInterval = Duration.ofMinutes(5);
@@ -109,6 +112,7 @@ public class Config {
      */
     public Config(Config config) {
         this.acceptorAddress = config.getAcceptorAddress();
+        this.peerAddress = config.getPeerAddress();
         this.acceptorPort = config.getAcceptorPort();
         this.peerDiscoveryInterval = config.getPeerDiscoveryInterval();
         this.peerConnectionRetryInterval = config.getPeerConnectionRetryInterval();
@@ -154,6 +158,25 @@ public class Config {
      */
     public InetAddress getAcceptorAddress() {
         return acceptorAddress;
+    }
+
+    /**
+     * @return the address to send to the tracker
+     * @since 1.10
+     */
+    public Optional<InetAddress> getPeerAddress() {
+        return peerAddress;
+    }
+
+    /**
+     * Set the address to send to the tracker. Useful if the local address to accept new connections differs from the
+     * remote address a user should connect to this client with for example in the case of NAT. Only supported for http
+     * trackers currently. Defaults to {@link #getAcceptorAddress()}
+     * @param peerAddress the address to send to the tracker.
+     * @since 1.10
+     */
+    public void setPeerAddress(InetAddress peerAddress) {
+        this.peerAddress = Optional.ofNullable(peerAddress);
     }
 
     /**

--- a/bt-tests/src/test/java/bt/data/TestFileSystemStorage.java
+++ b/bt-tests/src/test/java/bt/data/TestFileSystemStorage.java
@@ -97,4 +97,9 @@ class TestFileSystemStorage extends ExternalResource implements Storage {
 
         Files.delete(file.toPath());
     }
+
+    @Override
+    public void flush() {
+        // do nothing
+    }
 }

--- a/examples/src/main/java/yourip/mock/MockStorage.java
+++ b/examples/src/main/java/yourip/mock/MockStorage.java
@@ -27,4 +27,9 @@ public class MockStorage implements Storage {
     public StorageUnit getUnit(Torrent torrent, TorrentFile torrentFile) {
         return new MockStorageUnit();
     }
+
+    @Override
+    public void flush() {
+        // do nothing
+    }
 }


### PR DESCRIPTION
Hi,

Thanks for the fantastic work on this pure java torrent client. I am testing it with some torrents that have tens of thousands of files and found that it requires increasing the file descriptor limit so all files can be open concurrently.

I removed this requirement by implementing an LRU cache so only the most recently accessed files stay open. Also, I switched the file writing apis to FileChannel read/write so that multiple threads can concurrently read/write to different sections of an open file.

Lastly, I added one additional configuration option - allowing a separate ip address to be sent to the tracker (in the case of http trackers). This is necessary in certain networking configurations (NAT), as the listening address on the local system is not the same as the address which peers connect to.

I may also do some work soon to add callbacks for when individual files, and/or the entire torrent finishes. I have a use case that may require action after each individual file/the entire torrent completes.

Cheers,
Pyckle