### PR TITLE
Better Adherence to Bittorrent tracker Announce specification

### DIFF
--- a/bt-core/src/main/java/bt/peer/PeerRegistry.java
+++ b/bt-core/src/main/java/bt/peer/PeerRegistry.java
@@ -190,9 +190,8 @@ public class PeerRegistry implements IPeerRegistry {
                 Iterator<Peer> iter = discoveredPeers.iterator();
                 while (iter.hasNext()) {
                     Peer peer = iter.next();
-                    if (!addedPeers.contains(peer)) {
+                    if (addedPeers.add(peer)) {
                         addPeer(torrentId, peer);
-                        addedPeers.add(peer);
                     }
                     iter.remove();
                 }

--- a/bt-core/src/main/java/bt/peer/TrackerPeerSourceFactory.java
+++ b/bt-core/src/main/java/bt/peer/TrackerPeerSourceFactory.java
@@ -90,28 +90,11 @@ class TrackerPeerSourceFactory implements PeerSourceFactory {
     }
 
     private TrackerPeerSource getOrCreateTrackerPeerSource(TorrentId torrentId, AnnounceKey announceKey) {
-        ConcurrentMap<AnnounceKey, TrackerPeerSource> map = getOrCreateTrackerPeerSourcesMap(torrentId);
-        TrackerPeerSource trackerPeerSource = map.get(announceKey);
-        if (trackerPeerSource == null) {
-            trackerPeerSource = createTrackerPeerSource(torrentId, announceKey);
-            TrackerPeerSource existing = map.putIfAbsent(announceKey, trackerPeerSource);
-            if (existing != null) {
-                trackerPeerSource = existing;
-            }
-        }
+        ConcurrentMap<AnnounceKey, TrackerPeerSource> torrentAnnouncerMap = peerSources.computeIfAbsent(torrentId,
+                k -> new ConcurrentHashMap<>());
+        TrackerPeerSource trackerPeerSource = torrentAnnouncerMap.computeIfAbsent(announceKey,
+                k -> createTrackerPeerSource(torrentId, announceKey));
         return trackerPeerSource;
-    }
-
-    private ConcurrentMap<AnnounceKey, TrackerPeerSource> getOrCreateTrackerPeerSourcesMap(TorrentId torrentId) {
-        ConcurrentMap<AnnounceKey, TrackerPeerSource> map = peerSources.get(torrentId);
-        if (map == null) {
-            map = new ConcurrentHashMap<>();
-            ConcurrentMap<AnnounceKey, TrackerPeerSource> existing = peerSources.putIfAbsent(torrentId, map);
-            if (existing != null) {
-                map = existing;
-            }
-        }
-        return map;
     }
 
     private TrackerPeerSource createTrackerPeerSource(TorrentId torrentId, AnnounceKey announceKey) {

--- a/bt-core/src/main/java/bt/processor/magnet/ProcessMagnetTorrentStage.java
+++ b/bt-core/src/main/java/bt/processor/magnet/ProcessMagnetTorrentStage.java
@@ -30,9 +30,4 @@ public class ProcessMagnetTorrentStage extends ProcessTorrentStage<MagnetContext
                                      EventSink eventSink) {
         super(next, torrentRegistry, trackerService, eventSink);
     }
-
-    @Override
-    protected void onStarted(MagnetContext context) {
-        // do not announce start, as it should have been done already per FetchMetadataStage
-    }
 }

--- a/bt-core/src/main/java/bt/processor/torrent/ProcessTorrentStage.java
+++ b/bt-core/src/main/java/bt/processor/torrent/ProcessTorrentStage.java
@@ -62,7 +62,6 @@ public class ProcessTorrentStage<C extends TorrentContext> extends TerminateOnEr
         }
 
         descriptor.start();
-        start(context);
 
         eventSink.fireTorrentStarted(torrentId);
 
@@ -72,18 +71,6 @@ public class ProcessTorrentStage<C extends TorrentContext> extends TerminateOnEr
         } catch (InterruptedException e) {
             throw new RuntimeException("Unexpectedly interrupted", e);
         }
-    }
-
-    private void start(C context) {
-        try {
-            onStarted(context);
-        } catch (Exception e) {
-            LOGGER.error("Unexpected error", e);
-        }
-    }
-
-    protected void onStarted(C context) {
-        context.getAnnouncer().ifPresent(TrackerAnnouncer::start);
     }
 
     private void complete(C context) {

--- a/bt-core/src/main/java/bt/torrent/TrackerAnnouncer.java
+++ b/bt-core/src/main/java/bt/torrent/TrackerAnnouncer.java
@@ -72,16 +72,6 @@ public class TrackerAnnouncer {
         }
     }
 
-    public void start() {
-        trackerOptional.ifPresent(tracker -> {
-            try {
-                processResponse(Event.start, tracker, prepareAnnounce(tracker).start());
-            } catch (Exception e) {
-                logTrackerError(Event.start, tracker, Optional.of(e), Optional.empty());
-            }
-        });
-    }
-
     public void stop() {
         trackerOptional.ifPresent(tracker -> {
             try {
@@ -93,9 +83,13 @@ public class TrackerAnnouncer {
     }
 
     public void complete() {
+        // TODO: We should store the peers returned from the completed response. Really, this should be done in PeerSource
         trackerOptional.ifPresent(tracker -> {
             try {
-                processResponse(Event.complete, tracker, prepareAnnounce(tracker).complete());
+                // do not send completed if the torrent was fully downloaded before we started. This is
+                // as per BEP-0003: "No 'completed' is sent if the file was complete when started."
+                if (sessionState.getDownloaded() > 0)
+                    processResponse(Event.complete, tracker, prepareAnnounce(tracker).complete());
             } catch (Exception e) {
                 logTrackerError(Event.complete, tracker, Optional.of(e), Optional.empty());
             }

--- a/bt-core/src/main/java/bt/tracker/ITrackerService.java
+++ b/bt-core/src/main/java/bt/tracker/ITrackerService.java
@@ -42,7 +42,7 @@ public interface ITrackerService {
     Tracker getTracker(String trackerUrl);
 
     /**
-     * Get a tracker by its' announce key
+     * Get a tracker by its announce key
      *
      * @return Either a single-tracker or a multi-tracker,
      *         depending of the type of the announce key


### PR DESCRIPTION
This pull request makes the following improvements:

* Peers received from the initial tracker connection are now used rather than discarded
* BT no longer makes two calls to the tracker on startup - one to announce the startup and the other to get peers.
* BT now respects tracker minimum announce intervals
* BT now does not send a completed event to the tracker if the torrent was already completed before it connected to the tracker
* BT does not send start events to all trackers in torrents with multiple trackers. Rather it waits for 
* The first tracker announce is synchronously waited for - this decreases the time to connect to the first peers returned from the tracker.

Still todo:
* Peers received from the completed event are not added/used
* Download / upload stats are not sent on tracker query events 