### PR TITLE
Improve tracker announce behavior, Decrease log spam on torrent stop

### DIFF
--- a/bt-core/src/main/java/bt/DefaultClient.java
+++ b/bt-core/src/main/java/bt/DefaultClient.java
@@ -150,6 +150,7 @@ class DefaultClient<C extends ProcessingContext> implements BtClient {
         return futureOptional.isPresent();
     }
 
+    @Override
     public boolean updateFilePriorities(FilePrioritySelector torrentFilePrioritySelector) {
         TorrentSessionState state = context.getState().orElse(null);
         if (state != null) {

--- a/bt-core/src/main/java/bt/data/DataDescriptor.java
+++ b/bt-core/src/main/java/bt/data/DataDescriptor.java
@@ -86,4 +86,19 @@ public interface DataDescriptor extends Closeable {
      * Wait for all of the pieces of the torrent to download
      */
     void waitForAllPieces() throws InterruptedException;
+
+    /**
+     * Check if the torrent was finished upon initial hashing
+     *
+     * @return true if the torrent file was complete upon initial hashing
+     */
+    boolean startedAsSeed();
+
+    /**
+     * Get the amount of data left to verify
+     *
+     * @return the amount of data left to verify
+     * @since 1.10
+     */
+    long getLeft();
 }

--- a/bt-core/src/main/java/bt/data/PieceUtils.java
+++ b/bt-core/src/main/java/bt/data/PieceUtils.java
@@ -70,8 +70,8 @@ public class PieceUtils {
         return new ReadWriteDataRange(nonEmptyStorageUnits, 0, limitInLastUnit);
     }
 
-    private static ChunkDescriptor buildChunkDescriptor(DataRange data, long blockSize, byte[] checksum) {
-        BlockRange<DataRange> blockData = Ranges.blockRange(data, blockSize);
+    private static ChunkDescriptor buildChunkDescriptor(DataRange data, long transferBlockSize, byte[] checksum) {
+        BlockRange<DataRange> blockData = Ranges.blockRange(data, transferBlockSize);
         SynchronizedRange<BlockRange<DataRange>> synchronizedRange = new SynchronizedRange<>(blockData);
         SynchronizedDataRange<BlockRange<DataRange>> synchronizedData =
                 new SynchronizedDataRange<>(synchronizedRange, BlockRange::getDelegate);

--- a/bt-core/src/main/java/bt/data/range/BlockRange.java
+++ b/bt-core/src/main/java/bt/data/range/BlockRange.java
@@ -36,8 +36,8 @@ public class BlockRange<T extends Range<T>> implements Range<BlockRange<T>>, Del
      *
      * @since 1.2
      */
-    BlockRange(Range<T> delegate, long blockSize) {
-        this(delegate, 0, new MutableBlockSet(delegate.length(), blockSize));
+    BlockRange(Range<T> delegate, long transferBlockSize) {
+        this(delegate, 0, new MutableBlockSet(delegate.length(), transferBlockSize));
     }
 
     private BlockRange(Range<T> delegate,

--- a/bt-core/src/main/java/bt/data/range/Ranges.java
+++ b/bt-core/src/main/java/bt/data/range/Ranges.java
@@ -29,8 +29,8 @@ public class Ranges {
     /**
      * @since 1.3
      */
-    public static <T extends Range<T>> BlockRange<T> blockRange(T range, long blockSize) {
-        return new BlockRange<>(range, blockSize);
+    public static <T extends Range<T>> BlockRange<T> blockRange(T range, long transferBlockSize) {
+        return new BlockRange<>(range, transferBlockSize);
     }
 
     /**

--- a/bt-core/src/main/java/bt/metainfo/MetadataService.java
+++ b/bt-core/src/main/java/bt/metainfo/MetadataService.java
@@ -17,16 +17,16 @@
 package bt.metainfo;
 
 import bt.BtException;
-import bt.bencoding.serializers.BEParser;
 import bt.bencoding.BEType;
+import bt.bencoding.model.BEObject;
+import bt.bencoding.model.BEObjectModel;
+import bt.bencoding.model.ValidationResult;
+import bt.bencoding.model.YamlBEObjectModelLoader;
+import bt.bencoding.serializers.BEParser;
 import bt.bencoding.types.BEInteger;
 import bt.bencoding.types.BEList;
 import bt.bencoding.types.BEMap;
-import bt.bencoding.model.BEObject;
-import bt.bencoding.model.BEObjectModel;
 import bt.bencoding.types.BEString;
-import bt.bencoding.model.ValidationResult;
-import bt.bencoding.model.YamlBEObjectModelLoader;
 import bt.service.CryptoUtil;
 import bt.tracker.AnnounceKey;
 import org.slf4j.Logger;

--- a/bt-core/src/main/java/bt/peer/IPeerRegistry.java
+++ b/bt-core/src/main/java/bt/peer/IPeerRegistry.java
@@ -49,4 +49,13 @@ public interface IPeerRegistry {
      * @since 1.3
      */
     void addPeerSource(TorrentId torrentId, AnnounceKey announceKey);
+
+    /**
+     * Trigger a collection of peers for the specified torrent. Should be called upon starting to download a torrent to
+     * improve startup time
+     *
+     * @param torrentId the torrent ID to Announce
+     * @since 1.10
+     */
+    void triggerPeerCollection(TorrentId torrentId);
 }

--- a/bt-core/src/main/java/bt/peer/PeerSource.java
+++ b/bt-core/src/main/java/bt/peer/PeerSource.java
@@ -21,6 +21,8 @@ import bt.net.Peer;
 import java.util.Collection;
 
 /**
+ * A source of peers for a torrent
+ *
  * @since 1.0
  */
 public interface PeerSource {

--- a/bt-core/src/main/java/bt/peer/TrackerPeerSourceFactory.java
+++ b/bt-core/src/main/java/bt/peer/TrackerPeerSourceFactory.java
@@ -16,6 +16,7 @@
 
 package bt.peer;
 
+import bt.event.EventSource;
 import bt.metainfo.Torrent;
 import bt.metainfo.TorrentId;
 import bt.net.Peer;
@@ -47,6 +48,7 @@ class TrackerPeerSourceFactory implements PeerSourceFactory {
     public TrackerPeerSourceFactory(ITrackerService trackerService,
                                     TorrentRegistry torrentRegistry,
                                     IRuntimeLifecycleBinder lifecycleBinder,
+                                    EventSource eventSource,
                                     Duration trackerQueryInterval,
                                     int port) {
         this.trackerService = trackerService;
@@ -62,6 +64,7 @@ class TrackerPeerSourceFactory implements PeerSourceFactory {
                 return new Thread(r, String.format("%d.bt.peer.tracker-peer-source-%d", port, i.incrementAndGet()));
             }
         });
+        eventSource.onTorrentStopped(null, e -> peerSources.remove(e.getTorrentId()));
         lifecycleBinder.onShutdown("Shutdown tracker peer sources", executor::shutdownNow);
     }
 

--- a/bt-core/src/main/java/bt/processor/TerminateOnErrorProcessingStage.java
+++ b/bt-core/src/main/java/bt/processor/TerminateOnErrorProcessingStage.java
@@ -36,6 +36,11 @@ public abstract class TerminateOnErrorProcessingStage<C extends ProcessingContex
     protected final ProcessingStage<C> doExecute(C context, ProcessingStage<C> next) {
         try {
             doExecute(context);
+        } catch (InterruptedException e) {
+            // when we stop the client, we get an interrupted exception. This is expected and should be logged on the
+            // debug level
+            LOGGER.debug("Thread was interrupted. will finalize context and terminate...", e);
+            next = null;
         } catch (Exception e) {
             LOGGER.error("Unexpected error during processing, will finalize context and terminate...", e);
             next = null; // terminate processing chain
@@ -49,5 +54,5 @@ public abstract class TerminateOnErrorProcessingStage<C extends ProcessingContex
      *
      * @since 1.5
      */
-    protected abstract void doExecute(C context);
+    protected abstract void doExecute(C context) throws InterruptedException;
 }

--- a/bt-core/src/main/java/bt/processor/TorrentProcessorFactory.java
+++ b/bt-core/src/main/java/bt/processor/TorrentProcessorFactory.java
@@ -114,7 +114,8 @@ public class TorrentProcessorFactory implements ProcessorFactory {
 
         ProcessingStage<TorrentContext> stage5 = new SeedStage<>(null, torrentRegistry);
 
-        ProcessingStage<TorrentContext> stage4 = new ProcessTorrentStage<>(stage5, torrentRegistry, trackerService, eventSink);
+        ProcessingStage<TorrentContext> stage4 = new ProcessTorrentStage<>(stage5, torrentRegistry, peerRegistry,
+                trackerService, eventSink);
 
         ProcessingStage<TorrentContext> stage3 = new ChooseFilesStage<>(stage4, torrentRegistry, config);
 
@@ -133,7 +134,8 @@ public class TorrentProcessorFactory implements ProcessorFactory {
 
         ProcessingStage<MagnetContext> stage5 = new SeedStage<>(null, torrentRegistry);
 
-        ProcessingStage<MagnetContext> stage4 = new ProcessMagnetTorrentStage(stage5, torrentRegistry, trackerService, eventSink);
+        ProcessingStage<MagnetContext> stage4 = new ProcessMagnetTorrentStage(stage5, torrentRegistry, peerRegistry,
+                trackerService, eventSink);
 
         ProcessingStage<MagnetContext> stage3 = new ChooseFilesStage<>(stage4, torrentRegistry, config);
 

--- a/bt-core/src/main/java/bt/processor/magnet/ProcessMagnetTorrentStage.java
+++ b/bt-core/src/main/java/bt/processor/magnet/ProcessMagnetTorrentStage.java
@@ -17,6 +17,7 @@
 package bt.processor.magnet;
 
 import bt.event.EventSink;
+import bt.peer.IPeerRegistry;
 import bt.processor.ProcessingStage;
 import bt.processor.torrent.ProcessTorrentStage;
 import bt.torrent.TorrentRegistry;
@@ -26,8 +27,9 @@ public class ProcessMagnetTorrentStage extends ProcessTorrentStage<MagnetContext
 
     public ProcessMagnetTorrentStage(ProcessingStage<MagnetContext> next,
                                      TorrentRegistry torrentRegistry,
+                                     IPeerRegistry peerRegistry,
                                      ITrackerService trackerService,
                                      EventSink eventSink) {
-        super(next, torrentRegistry, trackerService, eventSink);
+        super(next, torrentRegistry, peerRegistry, trackerService, eventSink);
     }
 }

--- a/bt-core/src/main/java/bt/processor/torrent/CreateSessionStage.java
+++ b/bt-core/src/main/java/bt/processor/torrent/CreateSessionStage.java
@@ -78,7 +78,10 @@ public class CreateSessionStage<C extends TorrentContext> extends TerminateOnErr
         TorrentWorker torrentWorker = new TorrentWorker(torrentId, messageDispatcher, connectionSource, peerWorkerFactory,
                 bitfieldSupplier, assignmentsSupplier, statisticsSupplier, eventSource, config);
 
-        context.setState(new DefaultTorrentSessionState(descriptor, torrentWorker, context.getPieceSelector()));
+        final DefaultTorrentSessionState sessionState = new DefaultTorrentSessionState(descriptor::getDataDescriptor,
+                torrentWorker, context.getPieceSelector());
+        torrentRegistry.registerSessionState(torrentId, sessionState);
+        context.setState(sessionState);
         context.setRouter(router);
     }
 

--- a/bt-core/src/main/java/bt/processor/torrent/InitializeTorrentProcessingStage.java
+++ b/bt-core/src/main/java/bt/processor/torrent/InitializeTorrentProcessingStage.java
@@ -41,12 +41,12 @@ import bt.torrent.messaging.RequestProducer;
 
 public class InitializeTorrentProcessingStage<C extends TorrentContext> extends TerminateOnErrorProcessingStage<C> {
 
-    private IPeerConnectionPool connectionPool;
-    private TorrentRegistry torrentRegistry;
-    private DataWorker dataWorker;
-    private IBufferedPieceRegistry bufferedPieceRegistry;
-    private EventSink eventSink;
-    private Config config;
+    private final IPeerConnectionPool connectionPool;
+    private final TorrentRegistry torrentRegistry;
+    private final DataWorker dataWorker;
+    private final IBufferedPieceRegistry bufferedPieceRegistry;
+    private final EventSink eventSink;
+    private final Config config;
 
     public InitializeTorrentProcessingStage(ProcessingStage<C> next,
                                             IPeerConnectionPool connectionPool,

--- a/bt-core/src/main/java/bt/processor/torrent/SeedStage.java
+++ b/bt-core/src/main/java/bt/processor/torrent/SeedStage.java
@@ -34,15 +34,11 @@ public class SeedStage<C extends TorrentContext> extends TerminateOnErrorProcess
     }
 
     @Override
-    protected void doExecute(C context) {
+    protected void doExecute(C context) throws InterruptedException {
         TorrentDescriptor descriptor = getDescriptor(context.getTorrentId().get());
 
         while (descriptor.isActive()) {
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                throw new RuntimeException("Unexpectedly interrupted", e);
-            }
+            Thread.sleep(1_000);
         }
     }
 

--- a/bt-core/src/main/java/bt/processor/torrent/TorrentContext.java
+++ b/bt-core/src/main/java/bt/processor/torrent/TorrentContext.java
@@ -51,7 +51,6 @@ public class TorrentContext implements ProcessingContext {
     private final FileDownloadCompleteCallback fileCompletionCallback; // nullable
     private final Storage storage;
     private final Supplier<Torrent> torrentSupplier;
-    private final CompletableFuture<?> torrentDownloadedFuture = new CompletableFuture<>(); // set when download completed
 
     /* all of these can be missing, depending on which stage is currently being executed */
     private volatile TorrentId torrentId;

--- a/bt-core/src/main/java/bt/runtime/Config.java
+++ b/bt-core/src/main/java/bt/runtime/Config.java
@@ -82,7 +82,7 @@ public class Config {
         this.peerConnectionTimeout = Duration.ofSeconds(30);
         this.peerHandshakeTimeout = Duration.ofSeconds(30);
         this.peerConnectionInactivityThreshold = Duration.ofMinutes(3);
-        this.trackerQueryInterval = Duration.ofMinutes(5);
+        this.trackerQueryInterval = null; // use interval returned in tracker response by default
         this.maxPeerConnections = 500;
         this.maxPeerConnectionsPerTorrent = maxPeerConnections; // assume single torrent per runtime by default; change this to (maxActive * 2) maybe?
         this.transferBlockSize = 16 * 1024; // 16 KB

--- a/bt-core/src/main/java/bt/torrent/DefaultTorrentDescriptor.java
+++ b/bt-core/src/main/java/bt/torrent/DefaultTorrentDescriptor.java
@@ -18,10 +18,14 @@ package bt.torrent;
 
 import bt.data.DataDescriptor;
 
+import java.util.Optional;
+
 class DefaultTorrentDescriptor implements TorrentDescriptor {
 
     // !! this can be null in case with magnets (and in the beginning of processing) !!
     private volatile DataDescriptor dataDescriptor;
+    // !! this can be null at the beginning of processing !!
+    private volatile TorrentSessionState sessionState;
 
     private volatile boolean active;
 
@@ -56,5 +60,14 @@ class DefaultTorrentDescriptor implements TorrentDescriptor {
 
     void setDataDescriptor(DataDescriptor dataDescriptor) {
         this.dataDescriptor = dataDescriptor;
+    }
+
+    @Override
+    public Optional<TorrentSessionState> getSessionState() {
+        return Optional.ofNullable(sessionState);
+    }
+
+    void setSessionState(TorrentSessionState sessionState) {
+        this.sessionState = sessionState;
     }
 }

--- a/bt-core/src/main/java/bt/torrent/TorrentDescriptor.java
+++ b/bt-core/src/main/java/bt/torrent/TorrentDescriptor.java
@@ -18,6 +18,8 @@ package bt.torrent;
 
 import bt.data.DataDescriptor;
 
+import java.util.Optional;
+
 /**
  * Provides an interface for controlling
  * the state of a torrent processing session.
@@ -58,4 +60,12 @@ public interface TorrentDescriptor {
      * @since 1.0
      */
     DataDescriptor getDataDescriptor();
+
+    /**
+     * Get the session state of this torrent. May be null depending upon the state of torrent processing
+     *
+     * @return the session state of this torrent
+     * @since 1.10
+     */
+    Optional<TorrentSessionState> getSessionState();
 }

--- a/bt-core/src/main/java/bt/torrent/TorrentRegistry.java
+++ b/bt-core/src/main/java/bt/torrent/TorrentRegistry.java
@@ -18,14 +18,11 @@ package bt.torrent;
 
 import bt.data.Storage;
 import bt.metainfo.Torrent;
-import bt.metainfo.TorrentFile;
 import bt.metainfo.TorrentId;
-import bt.processor.ProcessingContext;
 import bt.torrent.callbacks.FileDownloadCompleteCallback;
 
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 
 /**
  * Registry of all torrents known to the current runtime.
@@ -83,7 +80,7 @@ public interface TorrentRegistry {
      *                Will be used when creating a new torrent descriptor.
      * @return Torrent descriptor
      * @since 1.0
-     * @deprecated since 1.3 in favor of more clearly named {@link #register(Torrent, Storage)}
+     * @deprecated since 1.3 in favor of more clearly named {@link #register(Torrent, Storage, FileDownloadCompleteCallback)}
      */
     TorrentDescriptor getOrCreateDescriptor(Torrent torrent, Storage storage);
 
@@ -98,6 +95,15 @@ public interface TorrentRegistry {
      */
     TorrentDescriptor register(Torrent torrent, Storage storage,
                                FileDownloadCompleteCallback fileCompletionCallback);
+
+    /**
+     * Register a session state for the specified torrent
+     *
+     * @param torrentId the torrent id
+     * @param state     the session state of the torrent
+     * @since 1.10
+     */
+    void registerSessionState(TorrentId torrentId, TorrentSessionState state);
 
     /**
      * Get an existing torrent descriptor for a given torrent ID

--- a/bt-core/src/main/java/bt/torrent/TorrentSessionState.java
+++ b/bt-core/src/main/java/bt/torrent/TorrentSessionState.java
@@ -78,11 +78,19 @@ public interface TorrentSessionState {
     long getUploaded();
 
     /**
-     * Waits for all of this torrent's chunks to be downloaded
+     * Get the number of bytes left to verify
      *
-     * @throws InterruptedException if the torrent download is interrupted
+     * @return the number of bytes left to verify
+     * @since 1.10
      */
-    void waitForAllPieces() throws InterruptedException;
+    long getLeft();
+
+    /**
+     * Check if the torrent was finished upon initial hashing
+     *
+     * @return true if the torrent file was complete upon initial hashing
+     */
+    boolean startedAsSeed();
 
     /**
      * @return Collection of peers, that this session is connected to

--- a/bt-core/src/main/java/bt/torrent/TrackerAnnouncer.java
+++ b/bt-core/src/main/java/bt/torrent/TrackerAnnouncer.java
@@ -88,7 +88,7 @@ public class TrackerAnnouncer {
             try {
                 // do not send completed if the torrent was fully downloaded before we started. This is
                 // as per BEP-0003: "No 'completed' is sent if the file was complete when started."
-                if (sessionState.getDownloaded() > 0)
+                if (!sessionState.startedAsSeed())
                     processResponse(Event.complete, tracker, prepareAnnounce(tracker).complete());
             } catch (Exception e) {
                 logTrackerError(Event.complete, tracker, Optional.of(e), Optional.empty());
@@ -98,9 +98,7 @@ public class TrackerAnnouncer {
 
     private TrackerRequestBuilder prepareAnnounce(Tracker tracker) {
         return tracker.request(torrent.getTorrentId())
-                .downloaded(sessionState.getDownloaded())
-                .uploaded(sessionState.getUploaded())
-                .left(sessionState.getPiecesRemaining() * torrent.getChunkSize());
+                .numWant(0);
     }
 
     private void processResponse(Event event, Tracker tracker, TrackerResponse response) {

--- a/bt-core/src/main/java/bt/torrent/messaging/ConnectionState.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/ConnectionState.java
@@ -20,8 +20,15 @@ import bt.protocol.Cancel;
 import bt.protocol.Request;
 import bt.torrent.data.BlockWrite;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Contains basic information about a connection's state.
@@ -35,8 +42,8 @@ public class ConnectionState {
     private volatile boolean choking;
     private volatile boolean peerChoking;
 
-    private volatile long downloaded;
-    private volatile long uploaded;
+    private final AtomicLong downloaded = new AtomicLong();
+    private final AtomicLong uploaded = new AtomicLong();
 
     private Optional<Boolean> shouldChoke;
     private long lastChoked;
@@ -167,7 +174,7 @@ public class ConnectionState {
      * @since 1.0
      */
     public long getDownloaded() {
-        return downloaded;
+        return downloaded.get();
     }
 
     /**
@@ -175,7 +182,7 @@ public class ConnectionState {
      * @since 1.0
      */
     public void incrementDownloaded(long downloaded) {
-        this.downloaded += downloaded;
+        this.downloaded.getAndAdd(downloaded);
     }
 
     /**
@@ -183,7 +190,7 @@ public class ConnectionState {
      * @since 1.0
      */
     public long getUploaded() {
-        return uploaded;
+        return uploaded.get();
     }
 
     /**
@@ -191,7 +198,7 @@ public class ConnectionState {
      * @since 1.0
      */
     public void incrementUploaded(long uploaded) {
-        this.uploaded += uploaded;
+        this.uploaded.getAndAdd(uploaded);
     }
 
     /**

--- a/bt-core/src/main/java/bt/tracker/MultiTracker.java
+++ b/bt-core/src/main/java/bt/tracker/MultiTracker.java
@@ -93,19 +93,8 @@ class MultiTracker implements Tracker {
             private TrackerRequestBuilder getDelegate(Tracker tracker, TorrentId torrentId) {
                 TrackerRequestBuilder delegate = tracker.request(torrentId);
 
-                long downloaded = getDownloaded();
-                if (downloaded > 0) {
-                    delegate.downloaded(downloaded);
-                }
-
-                long uploaded = getUploaded();
-                if (uploaded > 0) {
-                    delegate.uploaded(uploaded);
-                }
-
-                long left = getLeft();
-                if (left > 0) {
-                    delegate.left(left);
+                if (getNumWant() != null) {
+                    delegate.numWant(getNumWant());
                 }
 
                 return delegate;

--- a/bt-core/src/main/java/bt/tracker/TrackerRequestBuilder.java
+++ b/bt-core/src/main/java/bt/tracker/TrackerRequestBuilder.java
@@ -28,11 +28,8 @@ import java.util.Objects;
  */
 public abstract class TrackerRequestBuilder {
 
-    private TorrentId torrentId;
-
-    private long uploaded;
-    private long downloaded;
-    private long left;
+    private final TorrentId torrentId;
+    private Integer numWant;
 
     /**
      * Create a tracker request builder for a given torrent ID
@@ -76,47 +73,17 @@ public abstract class TrackerRequestBuilder {
     public abstract TrackerResponse query();
 
     /**
-     * Optionally set the amount of data uploaded during the current session.
+     * Set the number of peers to request in this call to the tracker. Set to null to use the default value
      *
-     * @param uploaded Amount of data uploaded since the last announce, in bytes.
+     * @param numWant the number of peers to request from the tracker
      * @return Builder
-     * @since 1.0
+     * @since 1.10
      */
-    public TrackerRequestBuilder uploaded(long uploaded) {
-        if (uploaded < 0) {
-            throw new BtException("Invalid uploaded value: " + uploaded);
+    public TrackerRequestBuilder numWant(Integer numWant) {
+        if (numWant != null && numWant < 0) {
+            throw new BtException("Invalid numWant value: " + numWant);
         }
-        this.uploaded = uploaded;
-        return this;
-    }
-
-    /**
-     * Optionally set the amount of data downloaded during the current session.
-     *
-     * @param downloaded Amount of data downloaded since the last announce, in bytes.
-     * @return Builder
-     * @since 1.0
-     */
-    public TrackerRequestBuilder downloaded(long downloaded) {
-        if (downloaded < 0) {
-            throw new BtException("Invalid downloaded value: " + downloaded);
-        }
-        this.downloaded = downloaded;
-        return this;
-    }
-
-    /**
-     * Optionally set the amount of data left for the client to download.
-     *
-     * @param left Amount of data that is left for the client to complete the torrent download, in bytes.
-     * @return Builder
-     * @since 1.0
-     */
-    public TrackerRequestBuilder left(long left) {
-        if (left < 0) {
-            throw new BtException("Invalid left value: " + left);
-        }
-        this.left = left;
+        this.numWant = numWant;
         return this;
     }
 
@@ -128,23 +95,12 @@ public abstract class TrackerRequestBuilder {
     }
 
     /**
-     * @since 1.0
+     * Get the number of peers to request from the tracker, or null if the default value should be used
+     *
+     * @return the number of peers to request from the tracker
+     * @since 1.10
      */
-    public long getUploaded() {
-        return uploaded;
-    }
-
-    /**
-     * @since 1.0
-     */
-    public long getDownloaded() {
-        return downloaded;
-    }
-
-    /**
-     * @since 1.0
-     */
-    public long getLeft() {
-        return left;
+    public Integer getNumWant() {
+        return numWant;
     }
 }

--- a/bt-core/src/main/java/bt/tracker/udp/UdpTrackerFactory.java
+++ b/bt-core/src/main/java/bt/tracker/udp/UdpTrackerFactory.java
@@ -19,6 +19,7 @@ package bt.tracker.udp;
 import bt.runtime.Config;
 import bt.service.IRuntimeLifecycleBinder;
 import bt.service.IdentityService;
+import bt.torrent.TorrentRegistry;
 import bt.tracker.Tracker;
 import bt.tracker.TrackerFactory;
 import com.google.inject.Inject;
@@ -30,20 +31,23 @@ import com.google.inject.Inject;
  */
 public class UdpTrackerFactory implements TrackerFactory {
 
-    private IdentityService idService;
-    private IRuntimeLifecycleBinder lifecycleBinder;
-    private Config config;
+    private final IdentityService idService;
+    private final TorrentRegistry torrentRegistry;
+    private final IRuntimeLifecycleBinder lifecycleBinder;
+    private final Config config;
 
     @Inject
-    public UdpTrackerFactory(IdentityService idService, IRuntimeLifecycleBinder lifecycleBinder, Config config) {
+    public UdpTrackerFactory(IdentityService idService, TorrentRegistry torrentRegistry,
+                             IRuntimeLifecycleBinder lifecycleBinder, Config config) {
         this.idService = idService;
+        this.torrentRegistry = torrentRegistry;
         this.lifecycleBinder = lifecycleBinder;
         this.config = config;
     }
 
     @Override
     public Tracker getTracker(String trackerUrl) {
-        return new UdpTracker(idService, lifecycleBinder, config.getAcceptorAddress(), config.getAcceptorPort(),
-                config.getNumberOfPeersToRequestFromTracker(), trackerUrl);
+        return new UdpTracker(idService, torrentRegistry, lifecycleBinder, config.getAcceptorAddress(),
+                config.getAcceptorPort(), config.getNumberOfPeersToRequestFromTracker(), trackerUrl);
     }
 }

--- a/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTrackerFactory.java
+++ b/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTrackerFactory.java
@@ -20,6 +20,7 @@ import bt.peer.IPeerRegistry;
 import bt.protocol.crypto.EncryptionPolicy;
 import bt.runtime.Config;
 import bt.service.IdentityService;
+import bt.torrent.TorrentRegistry;
 import bt.tracker.Tracker;
 import bt.tracker.TrackerFactory;
 import com.google.inject.Inject;
@@ -33,14 +34,19 @@ import java.net.InetAddress;
  */
 public class HttpTrackerFactory implements TrackerFactory {
 
-    private IdentityService idService;
-    private IPeerRegistry peerRegistry;
-    private EncryptionPolicy encryptionPolicy;
-    private InetAddress localAddress;
-    private int numberOfPeersToRequestFromTracker;
+    private final TorrentRegistry torrentRegistry;
+    private final IdentityService idService;
+    private final IPeerRegistry peerRegistry;
+    private final EncryptionPolicy encryptionPolicy;
+    private final InetAddress localAddress;
+    private final int numberOfPeersToRequestFromTracker;
 
     @Inject
-    public HttpTrackerFactory(IdentityService idService, IPeerRegistry peerRegistry, Config config) {
+    public HttpTrackerFactory(TorrentRegistry torrentRegistry,
+                              IdentityService idService,
+                              IPeerRegistry peerRegistry,
+                              Config config) {
+        this.torrentRegistry = torrentRegistry;
         this.idService = idService;
         this.peerRegistry = peerRegistry;
         this.encryptionPolicy = config.getEncryptionPolicy();
@@ -50,7 +56,7 @@ public class HttpTrackerFactory implements TrackerFactory {
 
     @Override
     public Tracker getTracker(String trackerUrl) {
-        return new HttpTracker(trackerUrl, idService, peerRegistry, encryptionPolicy, localAddress,
-                numberOfPeersToRequestFromTracker);
+        return new HttpTracker(trackerUrl, torrentRegistry, idService, peerRegistry, encryptionPolicy,
+                localAddress, numberOfPeersToRequestFromTracker);
     }
 }

--- a/bt-tests/src/test/java/bt/data/ChunkDescriptor_FileStorageUnitTest.java
+++ b/bt-tests/src/test/java/bt/data/ChunkDescriptor_FileStorageUnitTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Parameterized.class)
 public class ChunkDescriptor_FileStorageUnitTest {
+    private static final int CHUNK_SIZE = 16;
 
     @Rule
     public TestFileSystemStorage storage = new TestFileSystemStorage();
@@ -57,7 +58,7 @@ public class ChunkDescriptor_FileStorageUnitTest {
     private ChunkVerifier verifier;
     private IDataDescriptorFactory dataDescriptorFactory;
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "DigestBufSize={0}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[]{1},
@@ -86,19 +87,18 @@ public class ChunkDescriptor_FileStorageUnitTest {
 
     /**************************************************************************************/
 
-    private byte[] SINGLE_FILE = new byte[] {
-            1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,
-            1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4,
-            1,2,1,2,3,1,2,3,4,5,6,7,8,9,1,2,
-            1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4
+    private final byte[] SINGLE_FILE = new byte[]{
+            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
+            1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 1, 2, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2,
+            1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4
     };
 
     private DataDescriptor createDataDescriptor_SingleFile(String fileName) {
 
-        long chunkSize = 16;
-        long fileSize = chunkSize * 4;
+        long fileSize = CHUNK_SIZE * 4;
 
-        Torrent torrent = mockTorrent(fileName, fileSize, chunkSize,
+        Torrent torrent = mockTorrent(fileName, fileSize, CHUNK_SIZE,
                 new byte[][]{
                         CryptoUtil.getSha1Digest(Arrays.copyOfRange(SINGLE_FILE, 0, 16)),
                         CryptoUtil.getSha1Digest(Arrays.copyOfRange(SINGLE_FILE, 16, 32)),
@@ -118,6 +118,7 @@ public class ChunkDescriptor_FileStorageUnitTest {
 
         String fileName = "1-single.bin";
         DataDescriptor descriptor = createDataDescriptor_SingleFile(fileName);
+        assertEquals(SINGLE_FILE.length, descriptor.getLeft());
         List<ChunkDescriptor> chunks = descriptor.getChunkDescriptors();
 
         chunks.get(0).getData().putBytes(TestUtil.sequence(8));
@@ -191,6 +192,7 @@ public class ChunkDescriptor_FileStorageUnitTest {
         writeBytesToFile(new File(storage.getRoot(), fileName), SINGLE_FILE);
 
         DataDescriptor descriptor = createDataDescriptor_SingleFile(fileName);
+        assertEquals(0L, descriptor.getLeft());
         List<ChunkDescriptor> chunks = descriptor.getChunkDescriptors();
 
         byte[] block;
@@ -214,27 +216,27 @@ public class ChunkDescriptor_FileStorageUnitTest {
 
     /**************************************************************************************/
 
-    private byte[] MULTI_FILE_1 = new byte[] {
-            1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,
-            1,2,3,4,1,2,3,4,1
+    private final byte[] MULTI_FILE_1 = new byte[]{
+            1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8,
+            1, 2, 3, 4, 1, 2, 3, 4, 1
     };
-    private byte[] MULTI_FILE_2 = new byte[] {
-                              2,3,4,1,2,3,4,
-            1,2,1,2,3,1,2,3,4,5,6
+    private final byte[] MULTI_FILE_2 = new byte[]{
+            2, 3, 4, 1, 2, 3, 4,
+            1, 2, 1, 2, 3, 1, 2, 3, 4, 5, 6
     };
-    private byte[] MULTI_FILE_3 = new byte[] {
-                                  7,8,9,1,2
+    private final byte[] MULTI_FILE_3 = new byte[]{
+            7, 8, 9, 1, 2
     };
-    private byte[] MULTI_FILE_4 = new byte[] {
-            1,2,3,4,1,2,3,4,1,2,3,4,1,2,3,4,
-            1,2,3,4,5,6,7,8,9,1,2,3,4,5,6
+    private final byte[] MULTI_FILE_4 = new byte[]{
+            1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6
     };
-    private byte[] MULTI_FILE_5 = new byte[] {
-                                          7,
-            1,1,2,3,4,5,6,7,8,9,1,2,3,4,5
+    private final byte[] MULTI_FILE_5 = new byte[]{
+            7,
+            1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5
     };
-    private byte[] MULTI_FILE_6 = new byte[] {
-                                          1
+    private final byte[] MULTI_FILE_6 = new byte[]{
+            1
     };
 
     private DataDescriptor createDataDescriptor_MultiFile(String fileName1, String fileName2, String fileName3,
@@ -245,12 +247,12 @@ public class ChunkDescriptor_FileStorageUnitTest {
 
         long chunkSize = 16;
         long torrentSize = chunkSize * 6;
-        long fileSize1 = 25,
-             fileSize2 = 18,
-             fileSize3 = 5,
-             fileSize4 = 31,
-             fileSize5 = 16,
-             fileSize6 = 1;
+        long fileSize1 = MULTI_FILE_1.length,
+                fileSize2 = MULTI_FILE_2.length,
+                fileSize3 = MULTI_FILE_3.length,
+                fileSize4 = MULTI_FILE_4.length,
+                fileSize5 = MULTI_FILE_5.length,
+                fileSize6 = MULTI_FILE_6.length;
 
         // sanity check
         assertEquals(torrentSize, fileSize1 + fileSize2 + fileSize3 + fileSize4 + fileSize5 + fileSize6);
@@ -282,7 +284,7 @@ public class ChunkDescriptor_FileStorageUnitTest {
         byte[] chunk5Hash = CryptoUtil.getSha1Digest(chunk5);
 
         Torrent torrent = mockTorrent(torrentName, torrentSize, chunkSize,
-                new byte[][] {chunk0Hash, chunk1Hash, chunk2Hash, chunk3Hash, chunk4Hash, chunk5Hash},
+                new byte[][]{chunk0Hash, chunk1Hash, chunk2Hash, chunk3Hash, chunk4Hash, chunk5Hash},
                 mockTorrentFile(fileSize1, fileName1), mockTorrentFile(fileSize2, fileName2),
                 mockTorrentFile(fileSize3, fileName3), mockTorrentFile(fileSize4, fileName4),
                 mockTorrentFile(fileSize5, fileName5), mockTorrentFile(fileSize6, fileName6));
@@ -301,58 +303,86 @@ public class ChunkDescriptor_FileStorageUnitTest {
         String extension = "-multi.bin";
 
         String fileName1 = 1 + extension,
-               fileName2 = 2 + extension,
-               fileName3 = 3 + extension,
-               fileName4 = 4 + extension,
-               fileName5 = 5 + extension,
-               fileName6 = 6 + extension;
+                fileName2 = 2 + extension,
+                fileName3 = 3 + extension,
+                fileName4 = 4 + extension,
+                fileName5 = 5 + extension,
+                fileName6 = 6 + extension;
 
         DataDescriptor descriptor = createDataDescriptor_MultiFile(fileName1, fileName2, fileName3, fileName4,
                 fileName5, fileName6, torrentDirectory);
         List<ChunkDescriptor> chunks = descriptor.getChunkDescriptors();
 
-        chunks.get(0).getData().putBytes(TestUtil.sequence(8));
-        chunks.get(0).getData().getSubrange(8).putBytes(TestUtil.sequence(8));
-        assertTrue(chunks.get(0).isComplete());
-        assertTrue(verifier.verify(chunks.get(0)));
+        long dataLeft = CHUNK_SIZE * 6;
+        assertEquals(96L, descriptor.getLeft());
+        
+        
+        int pieceIdx = 0;
+        chunks.get(pieceIdx).getData().putBytes(TestUtil.sequence(8));
+        chunks.get(pieceIdx).getData().getSubrange(8).putBytes(TestUtil.sequence(8));
+        assertTrue(chunks.get(pieceIdx).isComplete());
+        assertTrue(verifier.verify(chunks.get(pieceIdx)));
+        assertTrue(descriptor.getBitfield().checkAndMarkVerified(pieceIdx));
+        dataLeft -= CHUNK_SIZE;
+        assertEquals(dataLeft, descriptor.getLeft());
 
-        chunks.get(1).getData().putBytes(TestUtil.sequence(4));
-        chunks.get(1).getData().getSubrange(4).putBytes(TestUtil.sequence(4));
-        chunks.get(1).getData().getSubrange(8).putBytes(TestUtil.sequence(4));
-        chunks.get(1).getData().getSubrange(12).putBytes(TestUtil.sequence(4));
-        assertTrue(chunks.get(1).isComplete());
+        pieceIdx = 1;
+        chunks.get(pieceIdx).getData().putBytes(TestUtil.sequence(4));
+        chunks.get(pieceIdx).getData().getSubrange(4).putBytes(TestUtil.sequence(4));
+        chunks.get(pieceIdx).getData().getSubrange(8).putBytes(TestUtil.sequence(4));
+        chunks.get(pieceIdx).getData().getSubrange(12).putBytes(TestUtil.sequence(4));
+        assertTrue(chunks.get(pieceIdx).isComplete());
         assertTrue(verifier.verify(chunks.get(1)));
+        assertTrue(descriptor.getBitfield().checkAndMarkVerified(pieceIdx));
+        dataLeft -= CHUNK_SIZE;
+        assertEquals(dataLeft, descriptor.getLeft());
 
         // reverse order
-        chunks.get(2).getData().getSubrange(5).putBytes(TestUtil.sequence(11));
-        chunks.get(2).getData().getSubrange(2).putBytes(TestUtil.sequence(3));
-        chunks.get(2).getData().putBytes(TestUtil.sequence(2));
-        assertFalse(chunks.get(2).isComplete());
-        chunks.get(2).getData().putBytes(new byte[]{1,2,1,2,3,1,2,3});
-        assertTrue(chunks.get(2).isComplete());
-        assertTrue(verifier.verify(chunks.get(2)));
+        pieceIdx = 2;
+        chunks.get(pieceIdx).getData().getSubrange(5).putBytes(TestUtil.sequence(11));
+        chunks.get(pieceIdx).getData().getSubrange(2).putBytes(TestUtil.sequence(3));
+        chunks.get(pieceIdx).getData().putBytes(TestUtil.sequence(2));
+        assertFalse(chunks.get(pieceIdx).isComplete());
+        chunks.get(pieceIdx).getData().putBytes(new byte[]{1, 2, 1, 2, 3, 1, 2, 3});
+        assertTrue(chunks.get(pieceIdx).isComplete());
+        assertTrue(verifier.verify(chunks.get(pieceIdx)));
+        assertTrue(descriptor.getBitfield().checkAndMarkVerified(pieceIdx));
+        dataLeft -= CHUNK_SIZE;
+        assertEquals(dataLeft, descriptor.getLeft());
 
         // "random" order
-        chunks.get(3).getData().getSubrange(4).putBytes(TestUtil.sequence(4));
-        chunks.get(3).getData().putBytes(TestUtil.sequence(4));
-        chunks.get(3).getData().getSubrange(12).putBytes(TestUtil.sequence(4));
-        chunks.get(3).getData().getSubrange(8).putBytes(TestUtil.sequence(4));
-        assertTrue(chunks.get(3).isComplete());
-        assertTrue(verifier.verify(chunks.get(3)));
+        pieceIdx = 3;
+        chunks.get(pieceIdx).getData().getSubrange(4).putBytes(TestUtil.sequence(4));
+        chunks.get(pieceIdx).getData().putBytes(TestUtil.sequence(4));
+        chunks.get(pieceIdx).getData().getSubrange(12).putBytes(TestUtil.sequence(4));
+        chunks.get(pieceIdx).getData().getSubrange(8).putBytes(TestUtil.sequence(4));
+        assertTrue(chunks.get(pieceIdx).isComplete());
+        assertTrue(verifier.verify(chunks.get(pieceIdx)));
+        assertTrue(descriptor.getBitfield().checkAndMarkVerified(pieceIdx));
+        dataLeft -= CHUNK_SIZE;
+        assertEquals(dataLeft, descriptor.getLeft());
 
         // block size same as chunk size
-        chunks.get(4).getData().putBytes(TestUtil.sequence(16));
-        assertTrue(chunks.get(4).isComplete());
-        assertTrue(verifier.verify(chunks.get(4)));
+        pieceIdx = 4;
+        chunks.get(pieceIdx).getData().putBytes(TestUtil.sequence(16));
+        assertTrue(chunks.get(pieceIdx).isComplete());
+        assertTrue(verifier.verify(chunks.get(pieceIdx)));
+        assertTrue(descriptor.getBitfield().checkAndMarkVerified(pieceIdx));
+        dataLeft -= CHUNK_SIZE;
+        assertEquals(dataLeft, descriptor.getLeft());
 
         // 1-byte blocks
-        chunks.get(5).getData().putBytes(TestUtil.sequence(1));
-        chunks.get(5).getData().getSubrange(15).putBytes(TestUtil.sequence(1));
-        chunks.get(5).getData().getSubrange(1).putBytes(TestUtil.sequence(14));
-        assertFalse(chunks.get(5).isComplete());
-        chunks.get(5).getData().putBytes(new byte[]{1,1,2,3,4,5,6,7,8,9,1,2,3,4,5,1});
-        assertTrue(chunks.get(5).isComplete());
-        assertTrue(verifier.verify(chunks.get(5)));
+        pieceIdx = 5;
+        chunks.get(pieceIdx).getData().putBytes(TestUtil.sequence(1));
+        chunks.get(pieceIdx).getData().getSubrange(15).putBytes(TestUtil.sequence(1));
+        chunks.get(pieceIdx).getData().getSubrange(1).putBytes(TestUtil.sequence(14));
+        assertFalse(chunks.get(pieceIdx).isComplete());
+        chunks.get(pieceIdx).getData().putBytes(new byte[]{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 1});
+        assertTrue(chunks.get(pieceIdx).isComplete());
+        assertTrue(verifier.verify(chunks.get(pieceIdx)));
+        assertTrue(descriptor.getBitfield().checkAndMarkVerified(pieceIdx));
+        dataLeft -= CHUNK_SIZE;
+        assertEquals(dataLeft, descriptor.getLeft());
 
         assertFileHasContents(new File(torrentDirectory, fileName1), MULTI_FILE_1);
         assertFileHasContents(new File(torrentDirectory, fileName2), MULTI_FILE_2);
@@ -373,11 +403,11 @@ public class ChunkDescriptor_FileStorageUnitTest {
         long chunkSize = 16;
         long torrentSize = 0;
         long fileSize1 = 0,
-             fileSize2 = 0,
-             fileSize3 = 0,
-             fileSize4 = 0,
-             fileSize5 = 0,
-             fileSize6 = 0;
+                fileSize2 = 0,
+                fileSize3 = 0,
+                fileSize4 = 0,
+                fileSize5 = 0,
+                fileSize6 = 0;
 
         // sanity check
         assertEquals(torrentSize, fileSize1 + fileSize2 + fileSize3 + fileSize4 + fileSize5 + fileSize6);
@@ -403,11 +433,11 @@ public class ChunkDescriptor_FileStorageUnitTest {
         String extension = "-multi.bin";
 
         String fileName1 = 1 + extension,
-               fileName2 = 2 + extension,
-               fileName3 = 3 + extension,
-               fileName4 = 4 + extension,
-               fileName5 = 5 + extension,
-               fileName6 = 6 + extension;
+                fileName2 = 2 + extension,
+                fileName3 = 3 + extension,
+                fileName4 = 4 + extension,
+                fileName5 = 5 + extension,
+                fileName6 = 6 + extension;
 
         DataDescriptor descriptor = createDataDescriptor_MultiEmptyFile(fileName1, fileName2, fileName3, fileName4,
                 fileName5, fileName6, torrentDirectory);
@@ -436,11 +466,11 @@ public class ChunkDescriptor_FileStorageUnitTest {
         String extension = "-multi.bin";
 
         String fileName1 = 1 + extension,
-               fileName2 = 2 + extension,
-               fileName3 = 3 + extension,
-               fileName4 = 4 + extension,
-               fileName5 = 5 + extension,
-               fileName6 = 6 + extension;
+                fileName2 = 2 + extension,
+                fileName3 = 3 + extension,
+                fileName4 = 4 + extension,
+                fileName5 = 5 + extension,
+                fileName6 = 6 + extension;
 
         writeBytesToFile(new File(torrentDirectory, fileName1), MULTI_FILE_1);
         writeBytesToFile(new File(torrentDirectory, fileName2), MULTI_FILE_2);


### PR DESCRIPTION
Avoid logging InterruptedException when a torrent is stopped

Fix BT Announce Behavior
* Correctly send left state to the tracker (currently this is always zero)
* Always send upload, download to the tracker, not just during the completion event.
* Trigger a tracker announce immediately after a torrent is started
* Request zero peers when stopping the torrent
* Request zero peers when the torrent is completed (the current code flow does not easily allow these peers to be put in the registry, so it's better not to request them)
* More robustly ensure that a completed event is not sent if the torrent was started as a seed
* Config change: follow default tracker announce interval if announce interval is unspecified
* Memory leak fix on torrent stop: remove extraTrackers and peerSources when a torrent is stopped