### PR TITLE
fix magnet link bug

### DIFF
--- a/bt-core/src/main/java/bt/torrent/DefaultTorrentSessionState.java
+++ b/bt-core/src/main/java/bt/torrent/DefaultTorrentSessionState.java
@@ -139,7 +139,10 @@ public class DefaultTorrentSessionState implements TorrentSessionState {
 
     @Override
     public long getLeft() {
-        return descriptor.get().getLeft();
+        if (descriptor.get() != null) {
+            return descriptor.get().getLeft();
+        }
+        return UNKNOWN;
     }
 
     @Override

--- a/bt-core/src/main/java/bt/torrent/TorrentSessionState.java
+++ b/bt-core/src/main/java/bt/torrent/TorrentSessionState.java
@@ -28,6 +28,10 @@ import java.util.Set;
  * @since 1.0
  */
 public interface TorrentSessionState {
+    /**
+     * The bytes returned when the data transfer is unknown
+     */
+    long UNKNOWN = -1;
 
     /**
      * @return Total number of pieces in the torrent
@@ -78,7 +82,7 @@ public interface TorrentSessionState {
     long getUploaded();
 
     /**
-     * Get the number of bytes left to verify
+     * Get the number of bytes left to verify, or {@link #UNKNOWN} if unknown (torrent not yet fetched)
      *
      * @return the number of bytes left to verify
      * @since 1.10
@@ -89,6 +93,7 @@ public interface TorrentSessionState {
      * Check if the torrent was finished upon initial hashing
      *
      * @return true if the torrent file was complete upon initial hashing
+     * @since 1.10
      */
     boolean startedAsSeed();
 

--- a/bt-core/src/main/java/bt/tracker/udp/UdpTracker.java
+++ b/bt-core/src/main/java/bt/tracker/udp/UdpTracker.java
@@ -19,8 +19,10 @@ package bt.tracker.udp;
 import bt.metainfo.TorrentId;
 import bt.service.IRuntimeLifecycleBinder;
 import bt.service.IdentityService;
+import bt.torrent.DefaultTorrentSessionState;
 import bt.torrent.TorrentDescriptor;
 import bt.torrent.TorrentRegistry;
+import bt.torrent.TorrentSessionState;
 import bt.tracker.Tracker;
 import bt.tracker.TrackerRequestBuilder;
 import bt.tracker.TrackerResponse;
@@ -144,7 +146,10 @@ class UdpTracker implements Tracker {
                         .ifPresent(state -> {
                             request.setDownloaded(state.getDownloaded());
                             request.setUploaded(state.getUploaded());
-                            request.setLeft(state.getLeft());
+                            long left = state.getLeft();
+                            if (left != TorrentSessionState.UNKNOWN) {
+                                request.setLeft(left);
+                            }
                         });
                 request.setNumwant(getNumWant() == null ? numberOfPeersToRequestFromTracker : getNumWant());
 

--- a/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTracker.java
+++ b/bt-http-tracker-client/src/main/java/bt/tracker/http/HttpTracker.java
@@ -24,6 +24,7 @@ import bt.protocol.crypto.EncryptionPolicy;
 import bt.service.IdentityService;
 import bt.torrent.TorrentDescriptor;
 import bt.torrent.TorrentRegistry;
+import bt.torrent.TorrentSessionState;
 import bt.tracker.SecretKey;
 import bt.tracker.Tracker;
 import bt.tracker.TrackerRequestBuilder;
@@ -233,7 +234,10 @@ public class HttpTracker implements Tracker {
                 .ifPresent(state -> {
                     queryBuilder.add("uploaded", state.getUploaded());
                     queryBuilder.add("downloaded", state.getDownloaded());
-                    queryBuilder.add("left", state.getLeft());
+                    long left = state.getLeft();
+                    if (left != TorrentSessionState.UNKNOWN) {
+                        queryBuilder.add("left", state.getLeft());
+                    }
                 });
 
         queryBuilder.add("compact", 1);


### PR DESCRIPTION
The MR fixes a minor bug that prevented tracker announcements from occurring before the torrent metadata is fetched from peers.