### PR TITLE
Determine getSha1Digest buffersize during runtime using metadata.length()

### DIFF
--- a/bt-core/src/main/java/bt/torrent/messaging/ExchangedMetadata.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/ExchangedMetadata.java
@@ -75,7 +75,10 @@ class ExchangedMetadata {
         if (digest == null) {
             synchronized (digestLock) {
                 if (digest == null) {
-                    digest = SHA1Digester.newDigester().digest(metadata);
+                    int bufferSize = metadata.length() < SHA1Digester.DEFAULT_BUFFER_SIZE
+                            ? (int) metadata.length()
+                            : SHA1Digester.DEFAULT_BUFFER_SIZE;
+                    digest = SHA1Digester.newDigester(bufferSize).digest(metadata);
                 }
             }
         }


### PR DESCRIPTION
To resolve #134.


This PR ensures that the buffer for `bt.torrent.messaging.ExchangedMetadata.getSha1Digest` is not larger than needed by using instead the smaller of `metadata.length()` and `DEFAULT_BUFFER_SIZE`.