### PR TITLE
Add new keystrokes to CliFileSelector

### DIFF
--- a/bt-cli/src/main/java/bt/cli/CliFileSelector.java
+++ b/bt-cli/src/main/java/bt/cli/CliFileSelector.java
@@ -26,13 +26,18 @@ import java.util.List;
 import java.util.Optional;
 
 public class CliFileSelector extends TorrentFileSelector {
-    private static final String PROMPT_MESSAGE_FORMAT = "Download '%s'? (hit <Enter> to confirm or <Esc> to skip)";
-    private static final String ILLEGAL_KEYPRESS_WARNING = "*** Invalid key pressed. Please, use only <Enter> or <Esc> ***";
+    private static final String PROMPT_MESSAGE_FORMAT = "Download '%s'? (Hit <Enter> to confirm, <Esc> to skip, <a> to confirm all remaining, <s> to skip all remaining or <q> to abort)";
+    private static final String ILLEGAL_KEYPRESS_WARNING = "*** Invalid key pressed. ***";
     private static final int EOF = -1;
     private static final int ESC = 0x1B;
+    private static final int CTRL_C = 3;
+    private static final int CTRL_D = 4;
 
     private final Optional<SessionStatePrinter> printer;
     private volatile boolean shutdown;
+
+    private boolean selectRemaining = false;
+    private boolean skipRemaining = false;
 
     public CliFileSelector() {
         this.printer = Optional.empty();
@@ -61,6 +66,12 @@ public class CliFileSelector extends TorrentFileSelector {
     @Override
     protected SelectionResult select(TorrentFile file) {
         while (!shutdown) {
+            if (selectRemaining) {
+                return SelectionResult.select().build();
+            } else if (skipRemaining) {
+                return SelectionResult.skip();
+            }
+
             System.out.println(getPromptMessage(file));
 
             try {
@@ -68,11 +79,28 @@ public class CliFileSelector extends TorrentFileSelector {
                     case EOF: {
                         throw new IllegalStateException("EOF");
                     }
+                    case 'a':
+                    case 'A': {
+                        selectRemaining = true;
+                        return SelectionResult.select().build();
+                    }
                     case '\n': { // <Enter>
                         return SelectionResult.select().build();
                     }
+                    case 's':
+                    case 'S': {
+                        skipRemaining = true;
+                        return SelectionResult.skip();
+                    }
                     case ESC: {
                         return SelectionResult.skip();
+                    }
+                    case CTRL_C:
+                    case CTRL_D:
+                    case 'q':
+                    case 'Q': {
+                        confirmAbort();
+                        break;
                     }
                     default: {
                         System.out.println(ILLEGAL_KEYPRESS_WARNING);
@@ -92,5 +120,21 @@ public class CliFileSelector extends TorrentFileSelector {
 
     private void shutdown() {
         this.shutdown = true;
+    }
+
+    private void confirmAbort() throws IOException {
+        System.out.println("Are you sure you want to abort (y/n)?");
+        switch (System.in.read()) {
+            case 'y':
+            case 'Y':
+            case CTRL_C:
+            case CTRL_D: {
+                System.out.println("Aborting...");
+                System.exit(0);
+            }
+            default: {
+                System.out.println("Resuming...");
+            }
+        }
     }
 }


### PR DESCRIPTION
To resolve #181 

This PR fixes the issue of needing to `kill -9` the process during file selection by properly handling interrupt signals as well as adding new key strokes to abort process or select/skip all remaining files.

One thing to note is that the prompt has become a bit unwieldy describing all the options, we would appreciate guidance on how this could be improved.