### PR TITLE
fix(sec): upgrade org.apache.logging.log4j:log4j-core to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <junit-version>4.12</junit-version>
         <mockito-version>1.10.19</mockito-version>
         <jimfs-version>1.1</jimfs-version>
-        <log4j-version>2.17.0</log4j-version>
+        <log4j-version>2.17.1</log4j-version>
     </properties>
 
     <scm>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.logging.log4j:log4j-core 2.17.0
- [CVE-2021-44832](https://www.oscs1024.com/hd/CVE-2021-44832)


### What did I do？
Upgrade org.apache.logging.log4j:log4j-core from 2.17.0 to 2.17.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS