### PR TITLE
Run file completion callbacks before torrent can be considered finished

### DIFF
--- a/bt-core/src/main/java/bt/data/LocalBitfield.java
+++ b/bt-core/src/main/java/bt/data/LocalBitfield.java
@@ -36,6 +36,9 @@ public abstract class LocalBitfield extends Bitfield {
     private final AtomicReference<BitSet> skipped = new AtomicReference<>();
 
     private final CountDownLatch latch;
+
+    // first list is the number of pieces in the torrent. Second list is a list of the files that are referenced
+    // by that piece
     private final Optional<List<List<CompletableTorrentFile>>> countdownFiles;
 
     public LocalBitfield(int piecesTotal,
@@ -47,7 +50,6 @@ public abstract class LocalBitfield extends Bitfield {
 
     public void markLocalPieceVerified(int pieceIndex) {
         if (checkAndMarkVerified(pieceIndex)) {
-            latch.countDown();
             countdownFiles.ifPresent(cdfList ->
                     cdfList.get(pieceIndex).forEach(
                             cdf -> {
@@ -56,6 +58,7 @@ public abstract class LocalBitfield extends Bitfield {
                                 }
                             })
             );
+            latch.countDown();
         }
     }
 


### PR DESCRIPTION
The current way the code is written, the torrent can be completed while a callback is still being executed. This is non-intuitive.

This fix runs the callback (if it exists) before completing the torrent.