### PR TITLE
Fix Performance and Memory Leak in MessageDispatcher Maps

### DIFF
--- a/bt-core/src/main/java/bt/metainfo/TorrentId.java
+++ b/bt-core/src/main/java/bt/metainfo/TorrentId.java
@@ -57,7 +57,7 @@ public class TorrentId {
         if (torrentId.length != TORRENT_ID_LENGTH) {
             throw new BtException("Illegal torrent ID length: " + torrentId.length);
         }
-        this.torrentId = torrentId;
+        this.torrentId = torrentId.clone();
         this.hashCode = Arrays.hashCode(torrentId);
     }
 

--- a/bt-core/src/main/java/bt/metainfo/TorrentId.java
+++ b/bt-core/src/main/java/bt/metainfo/TorrentId.java
@@ -50,6 +50,7 @@ public class TorrentId {
     }
 
     private final byte[] torrentId;
+    private final int hashCode;
 
     private TorrentId(byte[] torrentId) {
         Objects.requireNonNull(torrentId);
@@ -57,6 +58,7 @@ public class TorrentId {
             throw new BtException("Illegal torrent ID length: " + torrentId.length);
         }
         this.torrentId = torrentId;
+        this.hashCode = Arrays.hashCode(torrentId);
     }
 
     /**
@@ -69,7 +71,7 @@ public class TorrentId {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(torrentId);
+        return hashCode;
     }
 
     @Override

--- a/bt-core/src/main/java/bt/net/ConnectionKey.java
+++ b/bt-core/src/main/java/bt/net/ConnectionKey.java
@@ -25,6 +25,7 @@ public class ConnectionKey {
     private final Peer peer;
     private final int remotePort;
     private final TorrentId torrentId;
+    private final int hashCode;
 
     public ConnectionKey(Peer peer, int remotePort, TorrentId torrentId) {
         Objects.requireNonNull(peer);
@@ -32,6 +33,7 @@ public class ConnectionKey {
         this.peer = peer;
         this.remotePort = remotePort;
         this.torrentId = torrentId;
+        this.hashCode = computeHashCode();
     }
 
     public Peer getPeer() {
@@ -64,6 +66,10 @@ public class ConnectionKey {
 
     @Override
     public int hashCode() {
+        return hashCode;
+    }
+
+    private int computeHashCode() {
         int result = peer.getInetAddress().hashCode();
         result = 31 * result + remotePort;
         result = 31 * result + torrentId.hashCode();

--- a/bt-core/src/main/java/bt/net/IMessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/IMessageDispatcher.java
@@ -27,18 +27,11 @@ import java.util.function.Supplier;
  * @since 1.0
  */
 public interface IMessageDispatcher {
-
     /**
-     * Add a message consumer to receive messages from a remote peer for a given torrent.
+     * Set the message supplier for a newly connected peer
      *
-     * @since 1.7
+     * @since 1.11
      */
-    void addMessageConsumer(ConnectionKey connectionKey, Consumer<Message> messageConsumer);
-
-    /**
-     * Add a message supplier to send messages to a remote peer for a given torrent.
-     *
-     * @since 1.7
-     */
-    void addMessageSupplier(ConnectionKey connectionKey, Supplier<Message> messageSupplier);
+    void setConnectionMessageConsumerAndSupplier(ConnectionKey connectionKey, Consumer<Message> messageConsumer,
+            Supplier<Message> messageSupplier);
 }

--- a/bt-core/src/main/java/bt/net/IMessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/IMessageDispatcher.java
@@ -28,7 +28,7 @@ import java.util.function.Supplier;
  */
 public interface IMessageDispatcher {
     /**
-     * Set the message supplier for a newly connected peer
+     * Set the message supplier and consumer for a newly connected peer
      *
      * @since 1.11
      */

--- a/bt-core/src/main/java/bt/net/MessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/MessageDispatcher.java
@@ -25,7 +25,6 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,8 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-
-import static java.util.Collections.emptyMap;
 
 /**
  * Default single-threaded message dispatcher implementation.
@@ -196,8 +193,7 @@ public class MessageDispatcher implements IMessageDispatcher {
                 ConnectionKey connectionKey = e.getKey();
                 Supplier<Message> peerSupplier = e.getValue();
                 PeerConnection connection = pool.getConnection(connectionKey);
-                if (isActive(connection))
-                {
+                if (isActive(connection)) {
                     Message message;
                     try {
                         message = peerSupplier.get();

--- a/bt-core/src/main/java/bt/net/MessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/MessageDispatcher.java
@@ -34,6 +34,8 @@ import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static java.util.Collections.emptyMap;
+
 /**
  * Default single-threaded message dispatcher implementation.
  *
@@ -140,9 +142,7 @@ public class MessageDispatcher implements IMessageDispatcher {
         }
 
         private void processConsumerMap(TorrentId torrentId) {
-            Map<ConnectionKey, Collection<Consumer<Message>>> consumerMap = consumers.get(torrentId);
-            if (null == consumerMap)
-                return;
+            Map<ConnectionKey, Collection<Consumer<Message>>> consumerMap = consumers.getOrDefault(torrentId, emptyMap());
             Iterator<Map.Entry<ConnectionKey, Collection<Consumer<Message>>>> iter = consumerMap.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<ConnectionKey, Collection<Consumer<Message>>> e = iter.next();
@@ -197,9 +197,7 @@ public class MessageDispatcher implements IMessageDispatcher {
         }
 
         private void processSupplierMap(TorrentId torrentId) {
-            Map<ConnectionKey, Collection<Supplier<Message>>> supplierMap = suppliers.get(torrentId);
-            if (null == supplierMap)
-                return;
+            Map<ConnectionKey, Collection<Supplier<Message>>> supplierMap = suppliers.getOrDefault(torrentId, emptyMap());
             Iterator<Map.Entry<ConnectionKey, Collection<Supplier<Message>>>> iter = supplierMap.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<ConnectionKey, Collection<Supplier<Message>>> e = iter.next();

--- a/bt-core/src/main/java/bt/net/MessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/MessageDispatcher.java
@@ -141,6 +141,8 @@ public class MessageDispatcher implements IMessageDispatcher {
 
         private void processConsumerMap(TorrentId torrentId) {
             Map<ConnectionKey, Collection<Consumer<Message>>> consumerMap = consumers.get(torrentId);
+            if (null == consumerMap)
+                return;
             Iterator<Map.Entry<ConnectionKey, Collection<Consumer<Message>>>> iter = consumerMap.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<ConnectionKey, Collection<Consumer<Message>>> e = iter.next();
@@ -196,6 +198,8 @@ public class MessageDispatcher implements IMessageDispatcher {
 
         private void processSupplierMap(TorrentId torrentId) {
             Map<ConnectionKey, Collection<Supplier<Message>>> supplierMap = suppliers.get(torrentId);
+            if (null == supplierMap)
+                return;
             Iterator<Map.Entry<ConnectionKey, Collection<Supplier<Message>>>> iter = supplierMap.entrySet().iterator();
             while (iter.hasNext()) {
                 Map.Entry<ConnectionKey, Collection<Supplier<Message>>> e = iter.next();

--- a/bt-core/src/main/java/bt/net/MessageDispatcher.java
+++ b/bt-core/src/main/java/bt/net/MessageDispatcher.java
@@ -231,9 +231,7 @@ public class MessageDispatcher implements IMessageDispatcher {
                             }
                         }
                     } else {
-                        synchronized (modificationLock) {
-                            removeInactiveConnection(connectionKey, iter);
-                        }
+                        removeInactiveConnection(connectionKey, iter);
                     }
                 }
             }

--- a/bt-core/src/main/java/bt/torrent/messaging/TorrentWorker.java
+++ b/bt-core/src/main/java/bt/torrent/messaging/TorrentWorker.java
@@ -141,8 +141,8 @@ public class TorrentWorker {
             PieceAnnouncingPeerWorker worker = Objects.requireNonNull(createPeerWorker(connectionKey));
             PieceAnnouncingPeerWorker existing = peerMap.putIfAbsent(connectionKey, worker);
             if (existing == null) {
-                dispatcher.addMessageConsumer(connectionKey, message -> consume(connectionKey, message));
-                dispatcher.addMessageSupplier(connectionKey, () -> produce(connectionKey));
+                dispatcher.setConnectionMessageConsumerAndSupplier(connectionKey,
+                        message -> consume(connectionKey, message), () -> produce(connectionKey));
             } else {
                 // The peer was already present, so don't increment the count.
                 peerCount.decrementAndGet();

--- a/bt-tests/src/test/java/bt/torrent/messaging/RoutingPeerWorker_WithCompilerTest.java
+++ b/bt-tests/src/test/java/bt/torrent/messaging/RoutingPeerWorker_WithCompilerTest.java
@@ -27,7 +27,10 @@ import bt.torrent.annotation.Consumes;
 import bt.torrent.annotation.Produces;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -47,7 +50,7 @@ public class RoutingPeerWorker_WithCompilerTest {
     private PeerWorker peerWorker;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         this.c1 = new C1();
         this.p1 = new P1();
 
@@ -58,7 +61,9 @@ public class RoutingPeerWorker_WithCompilerTest {
 
         DefaultMessageRouter router = new DefaultMessageRouter(agents);
         IPeerWorkerFactory peerWorkerFactory = new PeerWorkerFactory(router);
-        ConnectionKey connectionKey = new ConnectionKey(mock(Peer.class),
+        Peer mock = mock(Peer.class);
+        Mockito.doReturn(InetAddress.getLocalHost()).when(mock).getInetAddress();
+        ConnectionKey connectionKey = new ConnectionKey(mock,
                 1, TorrentId.fromBytes(new byte[20]));
         this.peerWorker = peerWorkerFactory.createPeerWorker(connectionKey);
     }

--- a/bt-tests/src/test/java/bt/torrent/messaging/RoutingPeerWorker_WithCompilerTest.java
+++ b/bt-tests/src/test/java/bt/torrent/messaging/RoutingPeerWorker_WithCompilerTest.java
@@ -27,7 +27,6 @@ import bt.torrent.annotation.Consumes;
 import bt.torrent.annotation.Produces;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.net.InetAddress;
@@ -50,7 +49,7 @@ public class RoutingPeerWorker_WithCompilerTest {
     private PeerWorker peerWorker;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         this.c1 = new C1();
         this.p1 = new P1();
 
@@ -62,7 +61,7 @@ public class RoutingPeerWorker_WithCompilerTest {
         DefaultMessageRouter router = new DefaultMessageRouter(agents);
         IPeerWorkerFactory peerWorkerFactory = new PeerWorkerFactory(router);
         Peer mock = mock(Peer.class);
-        Mockito.doReturn(InetAddress.getLocalHost()).when(mock).getInetAddress();
+        Mockito.doReturn(InetAddress.getLoopbackAddress()).when(mock).getInetAddress();
         ConnectionKey connectionKey = new ConnectionKey(mock,
                 1, TorrentId.fromBytes(new byte[20]));
         this.peerWorker = peerWorkerFactory.createPeerWorker(connectionKey);


### PR DESCRIPTION
The supplier/consumer maps in MessageDispatcher store peer connections callbacks that are must be cleaned when a peer is disconnected.
Calls to isEmpty() are also removed which are O(n) for ConcurrentHashMap
hashCode for ConnectionKey and TorrentId are cached as this can become a bottleneck when the map is large.